### PR TITLE
Create docs dir, set up automatic build/deploy through workflow

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -1,0 +1,28 @@
+name: Build MkDocs
+
+on:
+  # Run on pushes to specified branches.
+  # TODO: Temp value of `create-docs` to test, but should become only $default-branch before switching to main
+  push:
+    branches: [ $default-branch, create-docs ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Build with MkDocs
+      uses: romw314/mkdocs-action@v9
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        path: docs/_site/
+        if-no-files-found: error
+
+  # TODO: deploy step that deploys to the actual website

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -34,8 +34,13 @@ jobs:
         # -r       : Recurse into directories
         # --delete : Delete files that are at the destination but not the source
         switches: -vzr --delete
-        path: _site
+
+        # the trailing slash on `path` ensures we copy the contents, not the dir itself.
+        # so we end up with `.../docs/index.html` not `.../docs/_site/index.html`
+        path: _site/
         remote_path: /home/heilalmond/getgrinnected.sites.grinnell.edu/docs
+
+        # ssh connection details
         remote_host: ${{ vars.SITES_SSH_HOSTNAME }}
         remote_port: ${{ vars.SITES_SSH_PORT }}
         remote_user: ${{ vars.SITES_SSH_USER }}

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -25,7 +25,8 @@ jobs:
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
+        name: docs-dir
         path: _site
         if-no-files-found: error
 
-  # TODO: deploy step that deploys to the actual website
+  # TODO: deploy job that deploys to the actual website through SSH

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -1,4 +1,4 @@
-name: Build MkDocs
+name: Build and Deploy MkDocs
 
 on:
   # Run on pushes to specified branches.
@@ -13,20 +13,24 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  build-deploy:
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout
       uses: actions/checkout@v4
 
+    # Build into _site dir
     - name: Build with MkDocs
       uses: romw314/mkdocs-action@v9
 
-    - name: Upload artifact
-      uses: actions/upload-artifact@v4
+    # Upload to server directory
+    - name: Deploy
+      uses: burnett01/rsync-deployments@7.0.2
       with:
-        name: docs-dir
+        switches: -avzr --delete
         path: _site
-        if-no-files-found: error
-
-  # TODO: deploy job that deploys to the actual website through SSH
+        remote_path: /home/heilalmond/getgrinnected.sites.grinnell.edu/docs
+        remote_host: ${{ vars.SITES_SSH_HOSTNAME }}
+        remote_port: ${{ vars.SITES_SSH_PORT }}
+        remote_user: ${{ vars.SITES_SSH_USER }}
+        remote_key: ${{ secrets.SSH_PRIVKEY }}

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -2,9 +2,8 @@ name: Build and Deploy MkDocs
 
 on:
   # Run on pushes to specified branches.
-  # TODO: Temp value of `create-docs` to test, but should become only $default-branch before switching to main
   push:
-    branches: [ $default-branch, create-docs ]
+    branches: [$default-branch]
     paths:
       - docs/**
       - mkdocs.yml

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -5,6 +5,9 @@ on:
   # TODO: Temp value of `create-docs` to test, but should become only $default-branch before switching to main
   push:
     branches: [ $default-branch, create-docs ]
+    paths:
+      - docs/**
+      - mkdocs.yml
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:
-        path: docs/_site/
+        path: _site
         if-no-files-found: error
 
   # TODO: deploy step that deploys to the actual website

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -23,11 +23,17 @@ jobs:
     - name: Build with MkDocs
       uses: romw314/mkdocs-action@v9
 
+    # TODO: UPLOAD ARTIFACT HERE IF NEEDED, BUT MAY NOT BE NEEDED
+
     # Upload to server directory
     - name: Deploy
       uses: burnett01/rsync-deployments@7.0.2
       with:
-        switches: -avzr --delete
+        # -v       : Verbose, print all transfers
+        # -z       : Compress files during transfer to save on bandwidth
+        # -r       : Recurse into directories
+        # --delete : Delete files that are at the destination but not the source
+        switches: -vzr --delete
         path: _site
         remote_path: /home/heilalmond/getgrinnected.sites.grinnell.edu/docs
         remote_host: ${{ vars.SITES_SSH_HOSTNAME }}

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -23,8 +23,6 @@ jobs:
     - name: Build with MkDocs
       uses: romw314/mkdocs-action@v9
 
-    # TODO: UPLOAD ARTIFACT HERE IF NEEDED, BUT MAY NOT BE NEEDED
-
     # Upload to server directory
     - name: Deploy
       uses: burnett01/rsync-deployments@7.0.2

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # IntelliJ IDEA config
 .idea
+
+# MkDocs build dir
+/site/

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ The structure of our Repository is as follows:
     - `backend` - Node.js (back-end)
 - `image-utils` - images/visual elements app will use
 
+- `mkdocs.yml` - MKDocs configuration file
+- `docs/` - Documentation pages
+
 # Issue Tracking
 
 [Trello](https://trello.com/invite/b/67aa2af610b85d0ead6a8419/ATTI86565b68d11ca1636671d8b646735837A143ECBB/getgrinnected)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,5 @@
+# Welcome to the GetGrinnected Docs!
+
+This is the place to find getting-started tutorials and guides to different functions of the app.
+
+At the moment, there's nothing here. Expect more in the future, but for now this is just a demo showing that the pages can actually be deployed.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,7 @@
+site_name: GetGrinnected Docs
+
+nav:
+  - Home: index.md
+
+theme:
+  name: material

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,14 @@
-site_name: GetGrinnected Docs
-
+# see https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation
 nav:
   - Home: index.md
 
-theme:
+################################################################################
+
+# displayed in the tab bar and as the page title
+site_name: GetGrinnected Docs
+
+# base URL where docs will be hosted. note that the "root" of MkDocs is a subdir of the usual site
+site_url: https://getgrinnected.sites.grinnell.edu/docs/
+
+theme: 
   name: material


### PR DESCRIPTION
This pull request sets up MkDocs for hand-written documentation, which will be where we can host some of our user guides and materials as detailed in the documentation plan. It also creates a Github action that will run when the doc files are changed by a push, which deploys them to our site.

# Note to reviewers

All actual documentation content is in `mkdocs.yaml` and `docs/`. The actual workflow is in `.github/workflows/mkdocs.yml`.

Currently, the docs are only a note saying that there's nothing there.

Ellie and I have worked together to test the workflow and make sure it's all okay.