### PR TITLE
Add getEventsBetween functionality to API, test API

### DIFF
--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -3,22 +3,23 @@
 
 name: Node.js CI
 
-# run on pull requests targeting main and pushes to development
+# run on pull requests targeting main and pushes to any branch
 on:
   pull_request:
     branches: [ $default-branch ]
     paths:
       - src/backend/**
+      - .github/workflows/node.yaml
   push:
-    branches: [ "development" ]
     paths:
       - src/backend/**
+      - .github/workflows/node.yaml
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 jobs:
-  test:
+  test-node:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -28,4 +29,4 @@ jobs:
         node-version: 22.x
         cache: 'npm'
     - run: npm ci
-    - run: npm run tests
+    - run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,10 @@
         "express": "^5.1.0",
         "fs": "^0.0.1-security",
         "mysql2": "^3.14.0"
+      },
+      "devDependencies": {
+        "lodash": "^4.17.21",
+        "supertest": "^7.1.0"
       }
     },
     "node_modules/@mapbox/node-pre-gyp": {
@@ -91,6 +95,20 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/aws-ssl-profiles": {
       "version": "1.1.2",
@@ -207,6 +225,29 @@
         "color-support": "bin.js"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -258,6 +299,13 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
@@ -273,6 +321,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/delegates": {
@@ -306,6 +364,17 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/dotenv": {
@@ -385,6 +454,22 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -442,6 +527,13 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/finalhandler": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
@@ -457,6 +549,60 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.2.tgz",
+      "integrity": "sha512-Jqc1btCy3QzRbJaICGwKcBfGWuLADRerLzDqi2NwSt/UkXLsHJw2TVResiaoBufHVHy9aSgClOHCeJsSsFLTbg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dezalgo": "^1.0.4",
+        "hexoid": "^2.0.0",
+        "once": "^1.4.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -634,6 +780,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
@@ -650,6 +812,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hexoid": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-2.0.0.tgz",
+      "integrity": "sha512-qlspKUK7IlSQv2o+5I7yhUd7TxlOG2Vr5LTa3ve2XSNVKAL/n/u/7KLvKmFNimomDIKvZFXWHv0T12mv7rT8Aw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/http-errors": {
@@ -740,6 +912,13 @@
       "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
       "license": "MIT"
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/long": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.1.tgz",
@@ -822,6 +1001,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/mime-db": {
@@ -1392,6 +1594,41 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-9.0.2.tgz",
+      "integrity": "sha512-xuW7dzkUpcJq7QnhOsnNUgtYp3xRwpt2F7abdRYIpCsAt0hhUqia0EdxyXZQQpNmGtsCzYHryaKSV3q3GJnq7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^3.5.1",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.1.0.tgz",
+      "integrity": "sha512-5QeSO8hSrKghtcWEoPiO036fxH0Ii2wVQfFZSP0oqQhmjk8bOLhDFXr4JrvaFmPuEWUoq4znY3uSi8UzLKxGqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
       }
     },
     "node_modules/tar": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "lodash": "^4.17.21",
+        "sinon": "^20.0.0",
         "supertest": "^7.1.0"
       }
     },
@@ -34,6 +35,48 @@
       },
       "bin": {
         "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "13.0.5",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
+      "integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1"
+      }
+    },
+    "node_modules/@sinonjs/samsam": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.2.tgz",
+      "integrity": "sha512-v46t/fwnhejRSFTGqbpn9u+LQ9xJDse10gNnPgAcxgdoCDMXj/G2asWAC/8Qs+BAZDicX+MNZouXT1A7c83kVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.1.0"
+      }
+    },
+    "node_modules/@sinonjs/samsam/node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/abbrev": {
@@ -375,6 +418,16 @@
       "dependencies": {
         "asap": "^2.0.0",
         "wrappy": "1"
+      }
+    },
+    "node_modules/diff": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/dotenv": {
@@ -768,6 +821,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -916,6 +979,14 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
       "dev": true,
       "license": "MIT"
     },
@@ -1543,6 +1614,24 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
     },
+    "node_modules/sinon": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-20.0.0.tgz",
+      "integrity": "sha512-+FXOAbdnj94AQIxH0w1v8gzNxkawVvNqE3jUzRLptR71Oykeu2RrQXXl/VQjKay+Qnh73fDt/oDfMo6xMeDQbQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.1",
+        "@sinonjs/fake-timers": "^13.0.5",
+        "@sinonjs/samsam": "^8.0.1",
+        "diff": "^7.0.0",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
     "node_modules/sqlstring": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
@@ -1631,6 +1720,19 @@
         "node": ">=14.18.0"
       }
     },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/tar": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
@@ -1662,6 +1764,16 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/type-is": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "lodash": "^4.17.21",
+    "sinon": "^20.0.0",
     "supertest": "^7.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,5 +12,9 @@
     "get_events": "node ./src/backend/fetch_events.js",
     "add_to_db": "node ./src/backend/database_add.js",
     "drop": "node ./src/backend/drop_expired.js"
+  },
+  "devDependencies": {
+    "lodash": "^4.17.21",
+    "supertest": "^7.1.0"
   }
 }

--- a/src/backend/api.js
+++ b/src/backend/api.js
@@ -100,13 +100,13 @@ async function getEventsBetween(req, res, next) {
   const end = parseParamDate(req.params.end);
   if (isNaN(start)) {
     res.status(400).json({
-      'message': 'Expected start time to match format YYYY-MM-DD(THH:MM:SS(z))',
+      'message': 'Expected start time to match format YYYY-MM-DD(THH:MM(z))',
       'start': req.params.start,
     });
     return;
   } else if (isNaN(end)) {
     res.status(400).json({
-      'message': 'Expected end time to match format YYYY-MM-DD(THH:MM:SS(z))',
+      'message': 'Expected end time to match format YYYY-MM-DD(THH:MM(z))',
       'end': req.params.end,
     });
     return;
@@ -149,9 +149,9 @@ async function getEventsBetween(req, res, next) {
  */
 function parseParamDate(paramDate) {
   // these are the three features we care about in our date format
-  const validDate = "\\d\\d\\d\\d-\\d\\d-\\d\\d"
-  const validTime = "T\\d\\d:\\d\\d:\\d\\d"
-  const validTimeZone = "[+-]\\d\\d\\d\\d"
+  const validDate = "\\d\\d\\d\\d-\\d\\d-\\d\\d"  // YYYY-MM-DD
+  const validTime = "T\\d\\d:\\d\\d"              // THH:MM, no seconds
+  const validTimeZone = "[+-]\\d\\d\\d\\d"        // Timezone, eg -0500 or +1230
 
   // If all features are specified, use that and respect the date and timezone provided
   const allFeaturesRegex = new RegExp('^' + validDate + validTime + validTimeZone + '$');
@@ -169,7 +169,7 @@ function parseParamDate(paramDate) {
   // If no timezone OR time is specified, assume they mean midnight at grinnell time
   const dateOnlyRegex = new RegExp('^' + validDate + '$');
   if (dateOnlyRegex.test(paramDate)) {
-    paramDate = paramDate.concat('T00:00:00-0500');
+    paramDate = paramDate.concat('T00:00-0500');
     return Date.parse(paramDate);
   }
 

--- a/src/backend/api.js
+++ b/src/backend/api.js
@@ -124,8 +124,7 @@ async function getEventsBetween(req, res, next) {
     return;
   }
 
-  // TODO: this split is already gross, and adding more things we can filter on would make it worse.
-  // we will want a better solution.
+  // If tags have been provided query the db for them.
   const events = await db.getEventsBetweenWithTags(start, end, tags);
   if (!events) {
     res.status(404).json({ 'message': 'No events found with tags', 'tags': tags });

--- a/src/backend/api.js
+++ b/src/backend/api.js
@@ -2,38 +2,174 @@ const express = require('express');
 const fs = require('fs');
 const db = require('./db_connect.js');
 
-// Listen on port 5844 by default
-const app = express();
-const port = process.env.PORT || 5844;
-app.listen(port, () => {
-  console.log(`Server listening on port ${port}`);
-});
+/* global var to store if we are running a server */
+var server = null;
 
-// Middleware to parse JSON requests
-app.use(express.json());
+/**
+ * Run the API.
+ */
+function run() {
+  // Listen on port 5844 by default
+  const app = express();
+  const port = process.env.PORT || 5844;
+  server = app.listen(port);
+  app.listen(port, () => {
+    console.log(`Server listening on port ${port}`);
+  });
 
-app.get('/', (req, res) => {
+  // Middleware to parse JSON requests
+  app.use(express.json());
+
+  // Basic GET route just to show the API is up.
+  app.get('/', getAPIOnline);
+
+  // Event GETs
+  app.get('/events', getEvents);
+  app.get('/events/between/:start/:end', getEventsBetween);
+}
+
+/**
+ * Stop running the API.
+ */
+function close() {
+  server.close((err) => {
+    console.log('server closed')
+    if (err) {
+      process.exit(err);
+    }
+  });
+}
+
+/**
+ * Just respond that the API is online.
+ *
+ * \param req Express request object
+ * \param res Express response object
+ */
+function getAPIOnline(req, res) {
   res.send('API online!');
-});
+}
 
-// GET all events
-// TODO: we want to be able to filter events, likely using queries.
-// TODO: for all these methods, we need to figure out some system of authorization or authentication. I forget which.
-app.get('/events', async function(req, res, next) {
-  const events = await db.getEvents();
+/**
+ * Query the database and respond with all known events in JSON.
+ * Supports querying for tags with query parameter `tag`.
+ *
+ * \param req  Express request object
+ * \param res  Express response object
+ * \param next Error handler function
+ */
+async function getEvents(req, res, next) {
+  // If they don't request tags, return all known events
+  const tags = parseQueryTags(req.query.tag);
+  console.log(`tags is ${JSON.stringify(tags)}`);
+  if (!tags) {
+    console.log("we don't need no tags");
+    const events = await db.getEvents();
+    res.json(events);
+  }
+
+  // If they do request tags, query the DB for them
+  // TODO: going here when not supposed to. fuckkkk
+  const events = await db.getEventsWithTags(tags);
+  if (!events) {
+    res.status(404).json({ 'message': 'No events found with tags', 'got': tags });
+  }
   res.json(events);
-});
+}
 
-// app.get('/events/:id', (req, res) => {
-//   const id = parseInt(req.params.id);
-//   const item = get_item_by_id(id);
-//   if (!item) {
-//     res.status(404).json({ error: 'Item not found' });
-//   } else {
-//     res.json(item);
-//   }
-// });
-//
-// function getItemByID(id) {
-//   return event_data.find((item) => item.ID === id);
-// }
+/**
+ * Query the database and respond with all events between two dates.
+ * Supports querying for tags with query parameter `tag`.
+ *
+ * \param req  Express request object
+ * \param res  Express response object
+ * \param next Error handler function
+ */
+async function getEventsBetween(req, res, next) {
+  // Try to parse the start and end times, fail if it does not work.
+  const start = parseParamTime(req.params.start);
+  const end = parseParamTime(req.params.end);
+  if (!start) {
+    res.status(400).json({ 'message': 'Time must follow YYYY-MM-DD, or YYYY-MM-DDTHH:MM:SS+ZZZZ format', 'got': req.params.start });
+  } else if (!end) {
+    res.status(400).json({ 'message': 'Time must follow YYYY-MM-DD, or YYYY-MM-DDTHH:MM:SS+ZZZZ format', 'got': req.params.end });
+  }
+
+  // If tags are not requested, simply query db.
+  const tags = parseQueryTags(req.query.tag);
+  if (!tags) { 
+    const events = { 'name': 'fake event', 'desc': 'db get events between' }; //await db.getEventsBetween(start, end); // TODO: implement in DB
+    res.json(events);
+  }
+
+  // TODO: this split is already gross, and adding more things we can filter on would make it worse.
+  // we will want a better solution.
+  const events = { 'name': 'fake event', 'desc': 'db get events between with tags' }; // await db.getEventsBetweenWithTags(start, end, tags); // TODO: implement in DB
+  if (!events) {
+    res.status(404).json({ 'message': 'No events found with tags', 'got': tags });
+  }
+  res.json(events);
+}
+
+/**
+ * Parse from a time URL parameter to a Unix timestamp.
+ *
+ * \param timeParam String representing a date.
+ * \returns Unix time equivalent if parseable, NaN if not.
+ */
+function parseParamDate(paramDate) {
+  // if time unspecified, assume Grinnell at midnight.
+  const regexTimezoneAtEnd = /[+-]\d\d\d\d$/
+  if (!paramDate.includes("T")) {
+    paramDate = paramDate.concat('T00:00:00-0500');
+  }
+
+  // if time is specified but there is no timezone, assume Grinnell time.
+  // timezones are either +#### or -####, thus the regex
+  else if (!regexTimezoneAtEnd.test(paramDate)) {
+    paramDate = paramDate.concat('-0500');
+  }
+
+  // let the date library parse the time now it is processed
+  return Date.parse(paramDate);
+}
+
+/**
+ * Parse from a query tag object to a well-formed list of individual tags. Tags with commas
+ * will be split to support queries like `?tag=a,b,c,d`.
+ *
+ * \param queryTags a query tag object, which can be either a list of strings or a string.
+ * \returns an array containing each tag.
+ */
+function parseQueryTags(queryTags) {
+  // Don't try parse zero-like tags
+  if (!queryTags) {
+    return [];
+  }
+
+  // If there is only one tag, it will not get put in a list. fix that.
+  if (!Array.isArray(queryTags)) {
+    queryTags = [queryTags];
+  }
+
+  // Split any comma-separated items like a,b,c
+  const tags = queryTags.map((x) => x.split(',')).flat();
+  return tags;
+}
+
+/*
+ * Depending on context, run or export
+ */
+if (require.main === module) {
+  run();
+} else {
+  module.exports = {
+    close,
+    getAPIOnline,
+    getEvents,
+    getEventsBetween,
+    parseParamDate,
+    parseQueryTags,
+    run
+  };
+}

--- a/src/backend/db_connect.js
+++ b/src/backend/db_connect.js
@@ -83,7 +83,7 @@ async function getEvents(){
  * \returns     A string that serves as a SQL selector for all those tags
  */
 function queryAllTags(tags) {
-    const pieces = tags.map((t) => `JSON_CONTAINS(tags, '"` + t + `"', '$')`);
+    const pieces = tags.map((t) => `JSON_CONTAINS(tags, '"` + pool.escape(t) + `"', '$')`);
     const piecesAndTogether = pieces.join(' AND ');
     return '(' + piecesAndTogether + ')';
 }
@@ -98,7 +98,7 @@ function queryAllTags(tags) {
 function queryBetweenDates(start, end) {
     // events where the start and end times are set
     // TODO: comparisons seem to not be working. need more work
-    const event_time_between = `(event_start_time < FROM_UNIXTIME(${start}) AND event_end_time > FROM_UNIXTIME(${end}))`
+    const event_time_between = `(event_start_time < FROM_UNIXTIME(${pool.escape(start)}) AND event_end_time > FROM_UNIXTIME(${pool.escape(end)}))`
 
     // TODO: handle events that are marked all day and therefore don't have a start time and end time
     // could it be done when scraping, maybe? this will SUCK to do in mysql.

--- a/src/backend/db_connect.js
+++ b/src/backend/db_connect.js
@@ -84,7 +84,7 @@ async function getEvents(){
  */
 function queryAllTags(tags) {
     const pieces = tags.map((t) => `JSON_CONTAINS(tags, '"` + t + `"', '$')`);
-    const piecesAndTogether = containsPieces.join(' AND ');
+    const piecesAndTogether = pieces.join(' AND ');
     return '(' + piecesAndTogether + ')';
 }
 
@@ -97,6 +97,7 @@ function queryAllTags(tags) {
  */
 function queryBetweenDates(start, end) {
     // events where the start and end times are set
+    // TODO: comparisons seem to not be working. need more work
     const event_time_between = `(event_start_time < FROM_UNIXTIME(${start}) AND event_end_time > FROM_UNIXTIME(${end}))`
 
     // TODO: handle events that are marked all day and therefore don't have a start time and end time

--- a/src/backend/db_connect.js
+++ b/src/backend/db_connect.js
@@ -77,19 +77,70 @@ async function getEvents(){
 }
 
 /**
+ * Construct a part of a query that selects for all tags.
+ *
+ * \param tags  List of string tags
+ * \returns     A string that serves as a SQL selector for all those tags
+ */
+function queryAllTags(tags) {
+    const pieces = tags.map((t) => `JSON_CONTAINS(tags, '"` + t + `"', '$')`);
+    const piecesAndTogether = containsPieces.join(' AND ');
+    return '(' + piecesAndTogether + ')';
+}
+
+/**
+ * Construct a part of a query that selects for events between a start and end time.
+ *
+ * \param start  Start time in Unix time
+ * \param end    End time in Unix time
+ * \returns      A string that serves as a SQL selector for those dates
+ */
+function queryBetweenDates(start, end) {
+    // events where the start and end times are set
+    const event_time_between = `(event_start_time < FROM_UNIXTIME(${start}) AND event_end_time > FROM_UNIXTIME(${end}))`
+
+    // TODO: handle events that are marked all day and therefore don't have a start time and end time
+    // could it be done when scraping, maybe? this will SUCK to do in mysql.
+
+    return event_time_between;
+}
+
+/**
  * Query the database for all events that have every tag in a list.
  *
  * \param tags  List of strings.
  * \returns     A list of all events that contain every tag in `tags`.
  */
-async function getEventsWithTags(tags){
-    // build up a query for all items that have tag1 AND tag2 AND ... AND tagN
-    // the query looks like JSON_CONTAINS(tags, '"tag1"', '$') AND JSON_CONTAINS(tags, '"tag2"', '$') ...
-    const containsPieces = tags.map((t) => `JSON_CONTAINS(tags, '"` + t + `"', '$')`);
-    const containsAllTags = containsPieces.join(' AND ');
-    const query = 'SELECT * FROM events WHERE ' + containsAllTags;
+async function getEventsWithTags(tags) {
+    const query = 'SELECT * FROM events WHERE ' + queryAllTags(tags);
+    const [events] = await pool.query(query);
+    return events;
+}
 
-    // actually make that query and return all matching events
+/**
+ * Query the database for events between two dates.
+ *
+ * \param start  Start date in unix time
+ * \param end    End date in unix time
+ * \returns      A list of all events between those dates
+ */
+async function getEventsBetween(start, end) {
+    const query = 'SELECT * FROM events WHERE ' + queryBetweenDates(start, end);
+    const [events] = await pool.query(query);
+    return events;
+}
+
+/**
+ * Query the database for events between two dates, that also have certain tags.
+ *
+ * \param start  Start date in unix time
+ * \param end    End date in unix time
+ * \param tags   List of tags that are required
+ * \returns      A list of all events between those dates that also have every tag
+ */
+async function getEventsBetweenWithTags(start, end, tags) {
+    const query = 'SELECT * FROM events WHERE ' + queryBetweenDates(start, end)
+        + ' AND ' + queryContainsAllTags(tags);
     const [events] = await pool.query(query);
     return events;
 }
@@ -161,7 +212,6 @@ async function verifyLogin(username, password){
     }
 }
 
-
 // Testing on Server
 
 //const setEvents = new Set([25625, 30582, 27740]);
@@ -193,5 +243,12 @@ if (require.main === module) {
     testLogins(); // TODO: move to different test? unknown if possible.
 } else {
     // File is being used as a module. Export it.
-    module.exports = { getEvents, getEventsWithTags, insertEventsFromScrape, dropExpiredEvents };
+    module.exports = {
+        dropExpiredEvents,
+        getEvents,
+        getEventsBetween,
+        getEventsBetweenWithTags,
+        getEventsWithTags,
+        insertEventsFromScrape,
+    };
 }

--- a/src/backend/db_connect.js
+++ b/src/backend/db_connect.js
@@ -82,7 +82,7 @@ async function getEvents(){
  * \param tags  List of strings.
  * \returns     A list of all events that contain every tag in `tags`.
  */
-async function getEventsWithAllTags(tags){
+async function getEventsWithTags(tags){
     // build up a query for all items that have tag1 AND tag2 AND ... AND tagN
     // the query looks like JSON_CONTAINS(tags, '"tag1"', '$') AND JSON_CONTAINS(tags, '"tag2"', '$') ...
     const containsPieces = tags.map((t) => `JSON_CONTAINS(tags, '"` + t + `"', '$')`);
@@ -193,5 +193,5 @@ if (require.main === module) {
     testLogins(); // TODO: move to different test? unknown if possible.
 } else {
     // File is being used as a module. Export it.
-    module.exports = { getEvents, getEventsWithAllTags, insertEventsFromScrape, dropExpiredEvents };
+    module.exports = { getEvents, getEventsWithTags, insertEventsFromScrape, dropExpiredEvents };
 }

--- a/src/backend/db_connect.js
+++ b/src/backend/db_connect.js
@@ -83,7 +83,8 @@ async function getEvents(){
  * \returns     A string that serves as a SQL selector for all those tags
  */
 function queryAllTags(tags) {
-    const pieces = tags.map((t) => `JSON_CONTAINS(tags, '"` + pool.escape(t) + `"', '$')`);
+    // escape the tag so that we will get a string query containing '\"tagnamne\"', for valid search
+    const pieces = tags.map((t) => `JSON_CONTAINS(tags, ${pool.escape(t)}, '$')`);
     const piecesAndTogether = pieces.join(' AND ');
     return '(' + piecesAndTogether + ')';
 }

--- a/src/backend/test/test_api.js
+++ b/src/backend/test/test_api.js
@@ -54,7 +54,8 @@ describe('Test API', () => {
 
 
 describe('parseParamDate', () => {
-    // Before any tests run, set our timezone to UTC so the Grinnell time will actually be tested.
+    // Before any tests run, set our timezone to UTC so 
+    // Grinnell time will actually be tested.
     before(() => {
         process.env.TZ = 'UTC';
     });
@@ -114,34 +115,49 @@ describe('parseQueryTags', () => {
         const input = null;
         const expected = [];
         const actual = api.parseQueryTags(input);
-        assert.ok(arraysEqual(expected, actual), `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+        assert.ok(
+            arraysEqual(expected, actual), 
+            `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`
+        );
     });
 
     it('should accept one tag', () => {
         const input = 'a';
         const expected = ['a'];
         const actual = api.parseQueryTags(input);
-        assert.ok(arraysEqual(expected, actual), `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+        assert.ok(
+            arraysEqual(expected, actual), 
+            `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`
+        );
     });
 
     it('should split one tag, comma separated', () => {
         const input = 'a,b,c';
         const expected = ['a', 'b', 'c'];
         const actual = api.parseQueryTags(input);
-        assert.ok(arraysEqual(expected, actual), `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+        assert.ok(
+            arraysEqual(expected, actual), 
+            `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`
+        );
     });
 
     it('should accept multiple tags, in a list', () => {
         const input = ['a', 'b', 'c'];
         const expected = ['a', 'b', 'c'];
         const actual = api.parseQueryTags(input);
-        assert.ok(arraysEqual(expected, actual), `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+        assert.ok(
+            arraysEqual(expected, actual), 
+            `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`
+        );
     });
 
     it('should split a mix of list and comma-separated tags', () => {
         const input = ['a', 'b,c', 'd'];
         const expected = ['a', 'b', 'c', 'd'];
         const actual = api.parseQueryTags(input);
-        assert.ok(arraysEqual(expected, actual), `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+        assert.ok(
+            arraysEqual(expected, actual), 
+            `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`
+        );
     });
 });

--- a/src/backend/test/test_api.js
+++ b/src/backend/test/test_api.js
@@ -1,0 +1,147 @@
+const { it, describe, mock, before, beforeEach, after } = require('node:test');
+const assert = require('node:assert/strict');
+const request = require("supertest");
+const _ = require('lodash');
+
+// require the file to be tested
+const api = require('../api');
+
+// return true if the arrays have all the same elements
+function arraysEqual(array1, array2) {
+    return _.isEmpty(_.xor(array1, array2));
+}
+
+describe('Test API', () => {
+    // Run API to start tests, and stop it on finish.
+    before(() => {
+        api.run();
+    });
+    after(() => {
+        api.close();
+    });
+
+    describe('GET /', () => {
+        it('should return online text', async () => {
+            const req = request('localhost:5844');
+            const res = await req.get('/');
+            assert.strictEqual(res.statusCode, 200);
+            assert.strictEqual(res.text, 'API online!');
+        });
+    });
+
+    /*
+    describe('GET /events', () => {
+        it('should work with no tags', async () => {
+            const req = request('localhost:5844');
+            const res = await req.get('/events');
+            assert.strictEqual(res.statusCode, 200);
+            console.log(JSON.stringify(res));
+            //assert.strictEqual(res.text, 'API online!');
+        });
+
+        it('should work with existing tags', async () => {
+        });
+
+        it('should return error with nonexistent tags', async () => {
+        });
+    });
+
+    describe('GET /events/between', () => {
+
+    });
+    */
+});
+
+
+describe('parseParamDate', () => {
+    // Before any tests run, set our timezone to UTC so the Grinnell time will actually be tested.
+    before(() => {
+        process.env.TZ = 'UTC';
+    });
+
+    it('should accept ISO-8601 time', () => {
+        const input = '2025-04-05T22:19-0500';
+        const expected = 1743909540000;
+        const actual = api.parseParamDate(input);
+        assert.strictEqual(expected, actual);
+    });
+
+    it('should respect ISO-8601 timezone', () => {
+        const input = '2022-03-12T10:32+1000';
+        const expected = 1647045120000;
+        const actual = api.parseParamDate(input);
+        assert.strictEqual(expected, actual);
+    });
+
+    it('should assume Grinnell time if timezone unspecified', () => {
+        const input = '2025-04-05T22:19';
+        const expected = 1743909540000;
+        const actual = api.parseParamDate(input);
+        assert.strictEqual(expected, actual);
+    });
+
+    it('should assume Grinnell midnight if no time specified', () => {
+        const input = '2025-04-05';
+        const expected = 1743829200000;
+        const actual = api.parseParamDate(input);
+        assert.strictEqual(expected, actual);
+    });
+
+    it('should not accept clearly malformed time', () => {
+        const input = 'this is not a date'
+        const expected = NaN;
+        const actual = api.parseParamDate(input);
+        assert.strictEqual(expected, actual);
+    });
+
+    it('should not accept dates with no separator', () => {
+        const input = '20250405'
+        const expected = NaN;
+        const actual = api.parseParamDate(input);
+        assert.strictEqual(expected, actual);
+    });
+
+    it('should not accept Unix time', () => {
+        const input = '1743909495';
+        const expected = NaN;
+        const actual = api.parseParamDate(input);
+        assert.strictEqual(expected, actual);
+    });
+});
+
+describe('parseQueryTags', () => {
+    it('should ignore empty tags', () => {
+        const input = null;
+        const expected = [];
+        const actual = api.parseQueryTags(input);
+        assert.ok(arraysEqual(expected, actual), `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+    });
+
+    it('should accept one tag', () => {
+        const input = 'a';
+        const expected = ['a'];
+        const actual = api.parseQueryTags(input);
+        assert.ok(arraysEqual(expected, actual), `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+    });
+
+    it('should split one tag, comma separated', () => {
+        const input = 'a,b,c';
+        const expected = ['a', 'b', 'c'];
+        const actual = api.parseQueryTags(input);
+        assert.ok(arraysEqual(expected, actual), `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+    });
+
+    it('should accept multiple tags, in a list', () => {
+        const input = ['a', 'b', 'c'];
+        const expected = ['a', 'b', 'c'];
+        const actual = api.parseQueryTags(input);
+        assert.ok(arraysEqual(expected, actual), `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+    });
+
+    it('should split a mix of list and comma-separated tags', () => {
+        const input = ['a', 'b,c', 'd'];
+        const expected = ['a', 'b', 'c', 'd'];
+        const actual = api.parseQueryTags(input);
+        assert.ok(arraysEqual(expected, actual), `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+    });
+});

--- a/src/backend/test/test_api.js
+++ b/src/backend/test/test_api.js
@@ -61,21 +61,21 @@ describe('parseParamDate', () => {
     });
 
     it('should accept ISO-8601 time', () => {
-        const input = '2025-04-05T22:19-0500';
+        const input = '2025-04-05T22:19:00-0500';
         const expected = 1743909540000;
         const actual = api.parseParamDate(input);
         assert.strictEqual(expected, actual);
     });
 
     it('should respect ISO-8601 timezone', () => {
-        const input = '2022-03-12T10:32+1000';
+        const input = '2022-03-12T10:32:00+1000';
         const expected = 1647045120000;
         const actual = api.parseParamDate(input);
         assert.strictEqual(expected, actual);
     });
 
     it('should assume Grinnell time if timezone unspecified', () => {
-        const input = '2025-04-05T22:19';
+        const input = '2025-04-05T22:19:00';
         const expected = 1743909540000;
         const actual = api.parseParamDate(input);
         assert.strictEqual(expected, actual);
@@ -104,6 +104,13 @@ describe('parseParamDate', () => {
 
     it('should not accept Unix time', () => {
         const input = '1743909495';
+        const expected = NaN;
+        const actual = api.parseParamDate(input);
+        assert.strictEqual(expected, actual);
+    });
+
+    it('should not accept natural language formatted dates', () => {
+        const input = 'March 3, 2002';
         const expected = NaN;
         const actual = api.parseParamDate(input);
         assert.strictEqual(expected, actual);

--- a/src/backend/test/test_api.js
+++ b/src/backend/test/test_api.js
@@ -49,67 +49,81 @@ describe('Test API', () => {
     describe('GET /events/between', () => {
 
     });
+
+    todo: between valid dates, assuming that parseParamDate already works
+
+    make sure to try invalid start + end dates to show you get the right errr
+
+    do also dates in the wrong order, also to get the right err
     */
 });
 
 
 describe('parseParamDate', () => {
     // Before any tests run, set our timezone to UTC so 
-    // Grinnell time will actually be tested.
+    // defaulting to Grinnell time will actually be tested
+    // (otherwise it will vary based on computer region)
     before(() => {
         process.env.TZ = 'UTC';
     });
 
-    it('should accept ISO-8601 time', () => {
-        const input = '2025-04-05T22:19:00-0500';
-        const expected = 1743909540000;
+    it('should accept ISO-8601 time unchanged', () => {
+        const input = '2025-04-05T22:19-0500';
+        const expected = Date.parse(input);
         const actual = api.parseParamDate(input);
         assert.strictEqual(expected, actual);
     });
 
-    it('should respect ISO-8601 timezone', () => {
-        const input = '2022-03-12T10:32:00+1000';
-        const expected = 1647045120000;
+    it('should respect non-Grinnell ISO-8601 timezones', () => {
+        const input = '2022-03-12T10:32+1230';
+        const expected = Date.parse(input);
         const actual = api.parseParamDate(input);
         assert.strictEqual(expected, actual);
     });
 
     it('should assume Grinnell time if timezone unspecified', () => {
-        const input = '2025-04-05T22:19:00';
-        const expected = 1743909540000;
+        const input = '1999-01-01T08:19';
+        const expected = Date.parse(input + '-0500');
         const actual = api.parseParamDate(input);
         assert.strictEqual(expected, actual);
     });
 
     it('should assume Grinnell midnight if no time specified', () => {
-        const input = '2025-04-05';
-        const expected = 1743829200000;
+        const input = '2025-08-04';
+        const expected = Date.parse(input + 'T00:00-0500');
         const actual = api.parseParamDate(input);
         assert.strictEqual(expected, actual);
     });
 
-    it('should not accept clearly malformed time', () => {
+    it('should reject clearly malformed time', () => {
         const input = 'this is not a date'
         const expected = NaN;
         const actual = api.parseParamDate(input);
         assert.strictEqual(expected, actual);
     });
 
-    it('should not accept dates with no separator', () => {
+    it('should reject date with seconds', () => {
+        const input = '2021-05-10T10:30:53-0500'
+        const expected = NaN;
+        const actual = api.parseParamDate(input);
+        assert.strictEqual(expected, actual);
+    });
+
+    it('should reject dates with no separator', () => {
         const input = '20250405'
         const expected = NaN;
         const actual = api.parseParamDate(input);
         assert.strictEqual(expected, actual);
     });
 
-    it('should not accept Unix time', () => {
+    it('should reject Unix time', () => {
         const input = '1743909495';
         const expected = NaN;
         const actual = api.parseParamDate(input);
         assert.strictEqual(expected, actual);
     });
 
-    it('should not accept natural language formatted dates', () => {
+    it('should reject natural language formatted dates', () => {
         const input = 'March 3, 2002';
         const expected = NaN;
         const actual = api.parseParamDate(input);


### PR DESCRIPTION
There's a lot in this pull request because there was a lot of work to do in order to get the API to a workable state. Here is a guide to reviewers by file.

* `.github/workflows/node.yaml`
  * Run on all branches, since we're getting rid of `development`
  * Run `npm test` instead of `npm run tests` since it's more common.
    * Still runs all the same tests, don't worry
* `src/backend/api.js`
  * make `run()` and `close()` functions that let you start/stop the API.
  * reorganize routes into their own functions
  * add /events/between/START/END route
  * write helpers to parse date params and tag query params
* `src/backend/db_connect.js`
  * create functions to get events between dates (tagged and not tagged)
  * make helpers that reduce repetition for making a query over all tags and a query between two dates
  * TODO: all-day events still need to be handled
* `src/backend/test/test_api.js`
  * test everything I implemented
  * useful tools: supertest for API testing, sinon for faking methods (to avoid hitting DB)