### PR TITLE
Allow API to run over HTTPS on server side

### DIFF
--- a/src/backend/api.js
+++ b/src/backend/api.js
@@ -16,8 +16,9 @@ function run() {
   const app = express();
   app.use(express.json());
 
-  // Create a regular HTTP server too. Backup.
-  const http_port = process.env.HTTP_PORT || 80;
+  // Create a regular HTTP server.
+  // Default to 8080 so non-root users can run it.
+  const http_port = process.env.HTTP_PORT || 8080;
   http_server = http.createServer(app).listen(http_port, () => {
     console.log(`http server listening on port  ${http_port}`);
   });
@@ -31,10 +32,13 @@ function run() {
   };
 
   // Create an HTTPS server serving the application.
-  const https_port = process.env.HTTPS_PORT || 443;
-  https_server = https.createServer(credentials, app).listen(https_port, () => {
-    console.log(`https server listening on port ${https_port}`);
-  });
+  // Default to 4443 so non-root users can run it.
+  const https_port = process.env.HTTPS_PORT || 4443;
+  https_server = https
+    .createServer(credentials, app)
+    .listen(https_port, () => {
+      console.log(`https server listening on port ${https_port}`);
+    });
 
   // Define routes
   app.get('/', getAPIOnline);

--- a/src/backend/api.js
+++ b/src/backend/api.js
@@ -12,19 +12,21 @@ var https_server = null;
  * Run the API.
  */
 function run() {
+  // Load environment vars from .env file
+  require('dotenv').config()
+
   // Create the app that we will serve
   const app = express();
   app.use(express.json());
 
   // Create a regular HTTP server.
   // Default to 8080 so non-root users can run it.
-  const http_port = process.env.HTTP_PORT || 8080;
+  const http_port = Number(process.env.HTTP_PORT) || 8080;
   http_server = http.createServer(app).listen(http_port, () => {
     console.log(`http server listening on port  ${http_port}`);
   });
 
   // Read SSL credentials from their system files
-  require('dotenv').config()
   const credentials = {
     key: process.env.SSL_KEY,
     ca: process.env.SSL_CA,
@@ -33,7 +35,7 @@ function run() {
 
   // Create an HTTPS server serving the application.
   // Default to 4443 so non-root users can run it.
-  const https_port = process.env.HTTPS_PORT || 4443;
+  const https_port = Number(process.env.HTTPS_PORT) || 4443;
   https_server = https
     .createServer(credentials, app)
     .listen(https_port, () => {

--- a/src/backend/api.js
+++ b/src/backend/api.js
@@ -1,28 +1,43 @@
+const db = require('./db_connect.js');
 const express = require('express');
 const fs = require('fs');
-const db = require('./db_connect.js');
+const http = require('http');
+const https = require('https');
 
 /* global var to store if we are running a server */
-var server = null;
+var http_server = null;
+var https_server = null;
 
 /**
  * Run the API.
  */
 function run() {
-  // Listen on port 5844 by default
+  // Create the app that we will serve
   const app = express();
-  const port = process.env.PORT || 5844;
-  server = app.listen(port, () => {
-    console.log(`server listening on port ${port}`);
-  });
-
-  // Middleware to parse JSON requests
   app.use(express.json());
 
-  // Basic GET route just to show the API is up.
-  app.get('/', getAPIOnline);
+  // Create a regular HTTP server too. Backup.
+  const http_port = process.env.HTTP_PORT || 80;
+  http_server = http.createServer(app).listen(http_port, () => {
+    console.log(`http server listening on port  ${http_port}`);
+  });
 
-  // GET events
+  // Read SSL credentials from their system files
+  require('dotenv').config()
+  const credentials = {
+    key: process.env.SSL_KEY,
+    ca: process.env.SSL_CA,
+    cert: process.env.SSL_CERT,
+  };
+
+  // Create an HTTPS server serving the application.
+  const https_port = process.env.HTTPS_PORT || 443;
+  https_server = https.createServer(credentials, app).listen(https_port, () => {
+    console.log(`https server listening on port ${https_port}`);
+  });
+
+  // Define routes
+  app.get('/', getAPIOnline);
   app.get('/events', getEvents);
   app.get('/events/between/:start/:end', getEventsBetween);
 }

--- a/src/backend/api.js
+++ b/src/backend/api.js
@@ -52,17 +52,27 @@ function run() {
  * Stop running the API. Uses the global `server` var set by run()
  */
 function close() {
-  if (server == null) {
-    return;
+  // close http server
+  if (http_server != null) {
+    http_server.close((err) => {
+      if (err) {
+        console.log(`http server closed with status ${err}`);
+      } else {
+        console.log(`http server closed with no error`);
+      }
+    });
   }
 
-  server.close((err) => {
-    if (err) {
-      console.log(`server closed with status ${err}`)
-    } else {
-      console.log('server closed with no error')
-    }
-  });
+  // close https server
+  if (https_server != null) {
+    https_server.close((err) => {
+      if (err) {
+        console.log(`https server closed with status ${err}`);
+      } else {
+        console.log(`https server closed with no error`);
+      }
+    });
+  }
 }
 
 /**

--- a/src/backend/test/test_api.js
+++ b/src/backend/test/test_api.js
@@ -29,7 +29,7 @@ describe('Test API', () => {
 
     describe('GET /', () => {
         it('should return online text', async () => {
-            const req = request('localhost:5844');
+            const req = request('http://localhost:8080');
             const res = await req.get('/');
             assert.strictEqual(res.statusCode, 200);
             assert.strictEqual(res.text, 'API online!');
@@ -54,7 +54,7 @@ describe('Test API', () => {
         });
 
         it('should call getEvents when no tags provided', async () => {
-            const req = request('localhost:5844');
+            const req = request('http://localhost:8080');
             const res = await req.get('/events');
             assert.strictEqual(res.statusCode, 200);
             assert.strictEqual(
@@ -64,7 +64,7 @@ describe('Test API', () => {
         });
 
         it('should call getEventsWithTags when tags are provided', async () => {
-            const req = request('localhost:5844');
+            const req = request('http://localhost:8080');
             const res = await req.get('/events?tag=exists');
             assert.strictEqual(res.statusCode, 200);
             assert.strictEqual(
@@ -74,7 +74,7 @@ describe('Test API', () => {
         });
 
         it('should fail to get tags when they do not exist', async () => {
-            const req = request('localhost:5844');
+            const req = request('http://localhost:8080');
             const res = await req.get('/events?tag=notexists');
             assert.strictEqual(res.statusCode, 404);
             assert.strictEqual(
@@ -105,7 +105,7 @@ describe('Test API', () => {
         });
 
         it('should work with valid dates', async () => {
-            const req = request('localhost:5844');
+            const req = request('http://localhost:8080');
             const res = await req.get('/events/between/2021-03-04/2021-03-06');
             assert.strictEqual(res.statusCode, 200);
             assert.strictEqual(
@@ -115,7 +115,7 @@ describe('Test API', () => {
         });
 
         it('should work with valid dates and tags', async () => {
-            const req = request('localhost:5844');
+            const req = request('http://localhost:8080');
             const res = await req.get('/events/between/2021-03-04/2021-03-06?tag=exists');
             assert.strictEqual(res.statusCode, 200);
             assert.strictEqual(
@@ -125,7 +125,7 @@ describe('Test API', () => {
         });
 
         it('should fail with invalid start date', async () => {
-            const req = request('localhost:5844');
+            const req = request('http://localhost:8080');
             const res = await req.get('/events/between/20210304/2021-03-06');
             assert.strictEqual(res.statusCode, 400);
             assert.strictEqual(
@@ -138,7 +138,7 @@ describe('Test API', () => {
         });
 
         it('should fail with invalid end date', async () => {
-            const req = request('localhost:5844');
+            const req = request('http://localhost:8080');
             const res = await req.get('/events/between/2021-03-06/2021-03-04');
             assert.strictEqual(res.statusCode, 400);
             assert.strictEqual(
@@ -155,7 +155,7 @@ describe('Test API', () => {
         });
 
         it('should fail with valid dates but invalid tags', async () => {
-            const req = request('localhost:5844');
+            const req = request('http://localhost:8080');
             const res = await req.get('/events/between/2021-03-04/2021-03-06?tag=notexist');
             assert.strictEqual(res.statusCode, 404);
             assert.strictEqual(

--- a/test procedures/api.md
+++ b/test procedures/api.md
@@ -41,7 +41,7 @@ For these steps, open a second terminal not connected to the server.
 
 1. Perform a curl request on the `/` route of the server.
    ```
-   curl 'http://node16049-csc324--spring2025.us.reclaim.cloud:11014/'
+   curl 'https://node16049-csc324--spring2025.us.reclaim.cloud/'
    ```
    
    > This will request the server load its default page, and then send the data back to you.
@@ -53,7 +53,7 @@ For these steps, open a second terminal not connected to the server.
 
 1. Perform this curl request.
    ```
-   curl 'http://node16049-csc324--spring2025.us.reclaim.cloud:11014/events' | jq
+   curl 'https://node16049-csc324--spring2025.us.reclaim.cloud/events' | jq
    ```
 
    > By piping the response of the server into `jq`, it will organize the JSON the server
@@ -69,7 +69,7 @@ For these steps, open a second terminal not connected to the server.
 
    Make sure to HTML escape it, such as by replacing spaces with `%20`.
    ```
-   curl 'http://node16049-csc324--spring2025.us.reclaim.cloud:11014/events?tag="TAGNAME"' | jq
+   curl 'https://node16049-csc324--spring2025.us.reclaim.cloud/events?tag="TAGNAME"' | jq
    ```
 
 2. Confirm that all events shown in the output have the tag you copied.
@@ -82,7 +82,7 @@ For these steps, open a second terminal not connected to the server.
 
    Make sure to HTML escape them, such as by replacing spaces with `%20`.
    ```
-   curl 'http://node16049-csc324--spring2025.us.reclaim.cloud:11014/events?tag="TAG1"&tag="TAG2"' | jq
+   curl 'https://node16049-csc324--spring2025.us.reclaim.cloud/events?tag="TAG1"&tag="TAG2"' | jq
    ```
 
 2. Confirm that all events shown have both of the tags you specified.
@@ -100,7 +100,7 @@ For these steps, open a second terminal not connected to the server.
 
 1. Perform this curl request.
    ```
-   curl 'http://node16049-csc324--spring2025.us.reclaim.cloud:11014/events?tag="doesnotexist"' | jq
+   curl 'https://node16049-csc324--spring2025.us.reclaim.cloud/events?tag="doesnotexist"' | jq
    ```
 
 2. Confirm the output is an empty array.

--- a/test procedures/api.md
+++ b/test procedures/api.md
@@ -30,7 +30,7 @@ To set up the test, do the following steps.
 6. Run the API from your checked-out directory
    ```
    npm ci
-   node src/backend/api.js
+   sudo node src/backend/api.js
    ```
 
 # What to test


### PR DESCRIPTION
This pull request changes the API so that it attempts to create an HTTP and an HTTPS server. If not configured it runs them on port 8080 (HTTP) and port 4443 (HTTPS).

Here's a breakdown.

1. In `src/backend/api.js`, I implemented the extra servers. They take environment config on what ports to run on. 
    - The server's `.env` file has been updated to make sure it runs on the right ports, and functionality has been tested manually.
3. In `src/backend/test/test_api.js`, I changed the tests to request through HTTP server specifically. The HTTPS server will not work through testing, since we can't set up the SSL certs there.
4. In `test procedures/api.md`, I changed the API to be run with sudo (to serve on ports 80 and 443, the default ports for HTTP and HTTPS). I also updated the `curl` commands in the tests so they check the correct server address.