### PR TITLE
Document current state of API

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -18,9 +18,18 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python_version: '3.13'
+        cache: pip
+      
+    - name: Install MkDocs and dependencies
+      run: python3 -m pip install mkdocs mkdocs-material mkdocs-render-swagger-plugin
+
     # Build into _site dir
-    - name: Build with MkDocs
-      uses: romw314/mkdocs-action@v9
+    - name: Build MkDocs
+      run: python3 -m mkdocs build --site-dir=_site
 
     # Upload to server directory
     - name: Deploy

--- a/docs/api-description.json
+++ b/docs/api-description.json
@@ -1,17 +1,8 @@
 {
   "openapi": "3.0.4",
   "info": {
-    "title": "GetGrinnected - OpenAPI 3.0",
-    "description": "This is the API documentation for GetGrinnected. Everything is still work-in-progress, and changes will happen.",
-    "license": {
-      "name": "MIT",
-      "url": "https://opensource.org/license/MIT"
-    },
+    "title": "GetGrinnected API",
     "version": "1.0"
-  },
-  "externalDocs": {
-    "description": "See the other docs",
-    "url": "https://getgrinnected.sites.grinnell.edu/docs/"
   },
   "servers": [
     {
@@ -36,18 +27,19 @@
           {
             "name": "tag",
             "in": "query",
-            "description": "Tags that events must have all of. Must be quoted in double quotes.",
+            "description": "Events must have all of these tags. Each tag needs double quotes.",
             "required": false,
             "explode": true,
             "schema": {
-              "type": "array",
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/Tags"
+                }
+              ],
               "example": [
                 "\"Music\"",
                 "\"Students\""
-              ],
-              "items": {
-                "type": "string"
-              }
+              ]
             }
           }
         ],
@@ -101,19 +93,20 @@
           },
           {
             "name": "tag",
+            "description": "Events must have all of these tags. Each tag needs double quotes.",
             "in": "query",
-            "description": "Tags that events must have all of. Must be quoted in double quotes.",
             "required": false,
             "explode": true,
             "schema": {
-              "type": "array",
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/Tags"
+                }
+              ],
               "example": [
                 "\"Music\"",
                 "\"Students\""
-              ],
-              "items": {
-                "type": "string"
-              }
+              ]
             }
           }
         ],

--- a/docs/api-description.json
+++ b/docs/api-description.json
@@ -1,0 +1,294 @@
+{
+  "openapi": "3.0.4",
+  "info": {
+    "title": "GetGrinnected - OpenAPI 3.0",
+    "description": "This is the API documentation for GetGrinnected. Everything is still work-in-progress, and changes will happen.",
+    "license": {
+      "name": "MIT",
+      "url": "https://opensource.org/license/MIT"
+    },
+    "version": "1.0"
+  },
+  "externalDocs": {
+    "description": "See the other docs",
+    "url": "https://getgrinnected.sites.grinnell.edu/docs/"
+  },
+  "servers": [
+    {
+      "url": "https://node16049-csc324--spring2025.us.reclaim.cloud/"
+    }
+  ],
+  "tags": [
+    {
+      "name": "events"
+    }
+  ],
+  "paths": {
+    "/events": {
+      "get": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Find all events.",
+        "description": "Find all events stored in the database.",
+        "operationId": "findAllEvents",
+        "parameters": [
+          {
+            "name": "tag",
+            "in": "query",
+            "description": "Tags that events must have all of. Must be quoted in double quotes.",
+            "required": false,
+            "explode": true,
+            "schema": {
+              "type": "array",
+              "example": [
+                "\"Music\"",
+                "\"Students\""
+              ],
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Event"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/events/between/{start}/{end}": {
+      "get": {
+        "tags": [
+          "events"
+        ],
+        "summary": "Find events between dates.",
+        "description": "Find all events between a start and end time.\n\n`start` and `end` parameters must match one of these valid formats:\n\n- `YYYY-MM-DD` for a date at midnight, in Grinnell time (UTC-5).\n- `YYYY-MM-DDTHH:MM` for a date and time, in Grinnell time (UTC-5).\n- `YYYY-MM-DDTHH:MMZ` for a date and time, in a specific timezone Timezones should be formatted like `-0600` or `+1200`.\n",
+        "operationId": "findEventsBetween",
+        "parameters": [
+          {
+            "name": "start",
+            "in": "path",
+            "description": "Start of the period to search. Format must match description above.",
+            "required": true,
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "2025-04-07"
+            }
+          },
+          {
+            "name": "end",
+            "in": "path",
+            "description": "End of the period to search. Format must match description above.",
+            "required": true,
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "example": "2025-04-08"
+            }
+          },
+          {
+            "name": "tag",
+            "in": "query",
+            "description": "Tags that events must have all of. Must be quoted in double quotes.",
+            "required": false,
+            "explode": true,
+            "schema": {
+              "type": "array",
+              "example": [
+                "\"Music\"",
+                "\"Students\""
+              ],
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Event"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "invalid parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Error"
+                    }
+                  ],
+                  "properties": {
+                    "code": {
+                      "example": "ERR_INVALID_DATE"
+                    },
+                    "message": {
+                      "example": "Got invalid date 20210102"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "example": "ERR_UNKNOWN"
+          },
+          "message": {
+            "type": "string",
+            "example": "Unknown error"
+          }
+        }
+      },
+      "Event": {
+        "type": "object",
+        "properties": {
+          "eventid": {
+            "type": "integer",
+            "example": 30881,
+            "description": "ID of the event in Grinnell Events."
+          },
+          "event_name": {
+            "type": "string",
+            "example": "Grinnell Advocates Karaoke",
+            "description": "Name of the event."
+          },
+          "event_description": {
+            "type": "string",
+            "example": "\\n  Grinnell Advocates Karaoke\\n",
+            "description": "Description of the event."
+          },
+          "event_location": {
+            "type": "string",
+            "example": "Bob’s Underground - Main Hall",
+            "description": "Location the event takes place."
+          },
+          "organizations": {
+            "type": "array",
+            "example": [
+              "Advocates",
+              " Crssj"
+            ],
+            "description": "Array of organizations in charge.",
+            "items": {
+              "description": "Organization names.",
+              "type": "string"
+            }
+          },
+          "rsvp": {
+            "type": "integer",
+            "example": 0,
+            "enum": [
+              0,
+              1
+            ],
+            "description": "Whether the event requires rsvp."
+          },
+          "event_date": {
+            "type": "string",
+            "example": "April 8",
+            "description": "Human-readable date the event takes place."
+          },
+          "event_all_day": {
+            "type": "integer",
+            "example": 0,
+            "enum": [
+              0,
+              1
+            ],
+            "description": "Whether the event is all-day."
+          },
+          "event_start_time": {
+            "type": "string",
+            "example": "2025-04-09T00:00:00.000Z",
+            "description": "Event start time in UTC."
+          },
+          "event_end_time": {
+            "type": "string",
+            "example": "2025-04-09T02:00:00.000Z",
+            "description": "Event end time in UTC"
+          },
+          "tags": {
+            "$ref": "#/components/schemas/Tags"
+          },
+          "event_private": {
+            "type": "integer",
+            "example": 0,
+            "description": "Whether the event is private.",
+            "enum": [
+              0,
+              1
+            ]
+          },
+          "repeats": {
+            "type": "integer",
+            "example": 0,
+            "description": "Whether the event repeats.",
+            "enum": [
+              0,
+              1
+            ]
+          },
+          "event_image": {
+            "type": "string",
+            "example": null,
+            "description": "Path to image for event."
+          },
+          "is_draft": {
+            "type": "integer",
+            "example": 0,
+            "description": "Whether the event is a draft.",
+            "enum": [
+              0,
+              1
+            ]
+          }
+        }
+      },
+      "Tags": {
+        "type": "array",
+        "example": [
+          "Music",
+          "Students"
+        ],
+        "description": "Array of event tags.",
+        "items": {
+          "description": "Tag names.",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/docs/api-v1.md
+++ b/docs/api-v1.md
@@ -1,3 +1,3 @@
-# API
+# API v1
 
 !!swagger api-description.json!!

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,3 @@
+# API
+
+!!swagger api-description.json!!

--- a/docs/swagger-code-colors.css
+++ b/docs/swagger-code-colors.css
@@ -1,0 +1,4 @@
+:root {
+    --md-code-bg-color: #333333;
+    --md-code-fg-color: #ffffff;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,7 @@
 # see https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation
 nav:
   - Home: index.md
+  - API: api.md
 
 ################################################################################
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,3 +12,6 @@ site_url: https://getgrinnected.sites.grinnell.edu/docs/
 
 theme: 
   name: material
+
+plugins:
+  - render_swagger

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 # see https://www.mkdocs.org/user-guide/writing-your-docs/#configure-pages-and-navigation
 nav:
   - Home: index.md
-  - API: api.md
+  - API v1: api-v1.md
 
 ################################################################################
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,3 +16,6 @@ theme:
 
 plugins:
   - render_swagger
+
+extra_css:
+  - swagger-code-colors.css


### PR DESCRIPTION
Add documentation for the current state of the API, and put these on the docs site. Publically available.

Currently the `/events/between/{start}/{end}/` route isn't working, but it does exist and is queryable. I'll try to fix it soon in another PR.

As you can see, most of the changes are the `api-description.json` file. If you want to preview that (to more easily make your comments) you can go to https://editor.swagger.io/ and choose File > Import file... from the top, then select a downloaded copy.