### PR TITLE
Fix Favorites and tags and Refactor Homepage

### DIFF
--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/Check.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/Check.kt
@@ -1,5 +1,7 @@
 package com.example.myapplication
 
+import androidx.compose.runtime.MutableState
+
 /**
  * This class is used to define the check data type
  * checked is a boolean that tracks whether the checkbox is checked or not
@@ -7,6 +9,6 @@ package com.example.myapplication
  */
 
 data class Check (
-    var checked: Boolean = false,
+    val checked: MutableState<Boolean>,
     val label: String,
 )

--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/CheckBox.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/CheckBox.kt
@@ -18,7 +18,6 @@ import androidx.compose.ui.Modifier
 
 @Composable
 fun CheckBox(check: Check) {
-    val checked = remember { mutableStateOf(check.checked) }
 
     Row(
         modifier = Modifier,
@@ -28,11 +27,9 @@ fun CheckBox(check: Check) {
     {
         //creates a checkbox
         Checkbox(
-            checked = checked.value,
-            onCheckedChange = {
-                checked.value = !checked.value
-                check.checked = !check.checked
-            })
+            checked = check.checked.value,
+            onCheckedChange = { check.checked.value = it }
+        )
         // checkbox label
         Text (check.label)
     }

--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/MainActivity.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/MainActivity.kt
@@ -6,6 +6,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.annotation.RequiresApi
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.lifecycle.lifecycleScope
 import com.example.myapplication.ui.theme.MyApplicationTheme
 import kotlinx.coroutines.flow.first
@@ -56,7 +57,7 @@ class MainActivity : ComponentActivity() {
                 val tagsString = events.flatMap { it.tags }.distinct()
 
                 // We turn this string of tags into a mutable list of check objects
-                val tags = tagsString.map { Check(false, it) }.toMutableList()
+                val tags = rememberSaveable(tagsString) { tagsString.map { Check(mutableStateOf(false), it) }.toMutableList() }
 
                 MyApplicationTheme(darkTheme = darkTheme.value, dynamicColor = false /* ensures our theme is displayed*/) {
                     AppNavigation(

--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/screens/HomeScreen.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/screens/HomeScreen.kt
@@ -124,7 +124,7 @@ fun HomeScreen(modifier: Modifier = Modifier, tags: MutableList<Check>) {
         Spacer(modifier = Modifier.height(150.dp))
         var tagSorter = 0
         repeat(tags.size){
-            if (tags[tagSorter].checked) {
+            if (tags[tagSorter].checked.value) {
                 chosenTags.add(tags[tagSorter].label)
             }
             tagSorter += 1

--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/screens/HomeScreen.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/screens/HomeScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -94,7 +95,11 @@ fun HomeScreen(modifier: Modifier = Modifier, tags: MutableList<Check>) {
     val check1 = remember { mutableStateOf(false)}
     val check2 = remember { mutableStateOf(false)}
     val check3 = remember { mutableStateOf(false)}
-    // path to API data
+
+    // Accessing colors from our theme
+    val colorScheme = MaterialTheme.colorScheme
+    // Accessing font info from our theme
+    val typography = MaterialTheme.typography
 
     // Gets events from our repo
     val eventEntities by AppRepository.events
@@ -111,7 +116,7 @@ fun HomeScreen(modifier: Modifier = Modifier, tags: MutableList<Check>) {
     Column1(
         modifier = Modifier
             // sets the color of the background
-            .background(gradient)
+            .background(color = colorScheme.background)
             .padding(horizontal = 8.dp)
             .fillMaxSize()
             .verticalScroll(state),
@@ -135,65 +140,51 @@ fun HomeScreen(modifier: Modifier = Modifier, tags: MutableList<Check>) {
             if (selectedView == 0) {
                 if (events[cardnum].event_start_time.substring(0, 10) == today.format(formatter).toString()){
                     EventCard(event = events[cardnum], modifier = Modifier
-                        .background(Color.White)
-                        .border(2.dp, Color.Black)
                     )
                     // creates space between cards
-                    Spacer(modifier = Modifier.height(8.dp))
+                    Spacer(modifier = Modifier.height(16.dp))
                 }
             } else if (selectedView == 1) {
                 if (events[cardnum].event_start_time.substring(0, 10) == tomorrow.format(formatter).toString()){
                     EventCard(event = events[cardnum], modifier = Modifier
-                        .background(Color.White)
-                        .border(2.dp, Color.Black)
                     )
                     // creates space between cards
-                    Spacer(modifier = Modifier.height(8.dp))
+                    Spacer(modifier = Modifier.height(16.dp))
                 }
             } else if (selectedView == 2) {
                 if (events[cardnum].event_start_time.substring(0, 10) == twodays.format(formatter).toString()){
                     EventCard(event = events[cardnum], modifier = Modifier
-                        .background(Color.White)
-                        .border(2.dp, Color.Black)
                     )
                     // creates space between cards
-                    Spacer(modifier = Modifier.height(8.dp))
+                    Spacer(modifier = Modifier.height(16.dp))
                 }
             } else if (selectedView == 3) {
                 if (events[cardnum].event_start_time.substring(0, 10) == threedays.format(formatter).toString()){
                     EventCard(event = events[cardnum], modifier = Modifier
-                        .background(Color.White)
-                        .border(2.dp, Color.Black)
                     )
                     // creates space between cards
-                    Spacer(modifier = Modifier.height(8.dp))
+                    Spacer(modifier = Modifier.height(16.dp))
                 }
             } else if (selectedView == 4) {
                 if (events[cardnum].event_start_time.substring(0, 10) == fourdays.format(formatter).toString()){
                     EventCard(event = events[cardnum], modifier = Modifier
-                        .background(Color.White)
-                        .border(2.dp, Color.Black)
                     )
                     // creates space between cards
-                    Spacer(modifier = Modifier.height(8.dp))
+                    Spacer(modifier = Modifier.height(16.dp))
                 }
             } else if (selectedView == 5) {
                 if (events[cardnum].event_start_time.substring(0, 10) == fivedays.format(formatter).toString()){
                     EventCard(event = events[cardnum], modifier = Modifier
-                        .background(Color.White)
-                        .border(2.dp, Color.Black)
                     )
                     // creates space between cards
-                    Spacer(modifier = Modifier.height(8.dp))
+                    Spacer(modifier = Modifier.height(16.dp))
                 }
             } else if(selectedView == 6){
                 if (events[cardnum].event_start_time.substring(0, 10) == sixdays.format(formatter).toString()){
                     EventCard(event = events[cardnum], modifier = Modifier
-                        .background(Color.White)
-                        .border(2.dp, Color.Black)
                     )
                     // creates space between cards
-                    Spacer(modifier = Modifier.height(8.dp))
+                    Spacer(modifier = Modifier.height(16.dp))
                 }
             }}
             // sorts by tag
@@ -204,57 +195,45 @@ fun HomeScreen(modifier: Modifier = Modifier, tags: MutableList<Check>) {
                         if (event[cardnum].event_start_time.substring(0, 10) == today.format(formatter).toString() && event[cardnum].tags.contains(chosenTags[t]))
                         {
                             EventCard(event = event[cardnum], modifier = Modifier
-                                .background(Color.White)
-                                .border(2.dp, Color.Black)
                             )
                             // creates space between cards
-                            Spacer(modifier = Modifier.height(8.dp))
+                            Spacer(modifier = Modifier.height(16.dp))
                         }
                     } else if (selectedView == 1) {
                         if (event[cardnum].event_start_time.substring(0, 10) == tomorrow.format(formatter).toString() && event[cardnum].tags.contains(chosenTags[t])){
                             EventCard(event = event[cardnum], modifier = Modifier
-                                .background(Color.White)
-                                .border(2.dp, Color.Black)
                             )
                             // creates space between cards
-                            Spacer(modifier = Modifier.height(8.dp))
+                            Spacer(modifier = Modifier.height(16.dp))
                         }
                     } else if (selectedView == 2) {
                         if (event[cardnum].event_start_time.substring(0, 10) == twodays.format(formatter).toString() && event[cardnum].tags.contains(chosenTags[t])){
                             EventCard(event = event[cardnum], modifier = Modifier
-                                .background(Color.White)
-                                .border(2.dp, Color.Black)
                             )
                             // creates space between cards
-                            Spacer(modifier = Modifier.height(8.dp))
+                            Spacer(modifier = Modifier.height(16.dp))
                         }
                     } else if (selectedView == 3) {
                         if (event[cardnum].event_start_time.substring(0, 10) == threedays.format(formatter).toString() && event[cardnum].tags.contains(chosenTags[t])){
                             EventCard(event = event[cardnum], modifier = Modifier
-                                .background(Color.White)
-                                .border(2.dp, Color.Black)
                             )
                             // creates space between cards
-                            Spacer(modifier = Modifier.height(8.dp))
+                            Spacer(modifier = Modifier.height(16.dp))
                         }
                     } else if (selectedView == 4) {
                         if (event[cardnum].event_start_time.substring(0, 10) == fourdays.format(formatter).toString() && event[cardnum].tags.contains(chosenTags[t])){
                             EventCard(event = event[cardnum], modifier = Modifier
-                                .background(Color.White)
-                                .border(2.dp, Color.Black)
                             )
                             // creates space between cards
-                            Spacer(modifier = Modifier.height(8.dp))
+                            Spacer(modifier = Modifier.height(16.dp))
                         }
                     } else if (selectedView == 5) {
                         if (event[cardnum].event_start_time.substring(0, 10) == fivedays.format(formatter).toString() && event[cardnum].tags.contains(chosenTags[t]))
                         {
                             EventCard(event = event[cardnum], modifier = Modifier
-                                .background(Color.White)
-                                .border(2.dp, Color.Black)
                             )
                             // creates space between cards
-                            Spacer(modifier = Modifier.height(8.dp))
+                            Spacer(modifier = Modifier.height(16.dp))
                         }
                     } else if(selectedView == 6) {
                         if (event[cardnum].event_start_time.substring(0, 10) == sixdays.format(
@@ -263,11 +242,9 @@ fun HomeScreen(modifier: Modifier = Modifier, tags: MutableList<Check>) {
                         ) {
                             EventCard(
                                 event = event[cardnum], modifier = Modifier
-                                    .background(Color.White)
-                                    .border(2.dp, Color.Black)
                             )
                             // creates space between cards
-                            Spacer(modifier = Modifier.height(8.dp))
+                            Spacer(modifier = Modifier.height(16.dp))
                         }
                     }
                     t += 1
@@ -279,13 +256,13 @@ fun HomeScreen(modifier: Modifier = Modifier, tags: MutableList<Check>) {
         }
         // creates a space at the bottom for visual appeal
         Spacer(modifier = Modifier.height(8.dp))
-        Text("No more events match filters" , fontSize = 26.sp, fontWeight = FontWeight.Bold)
+        Text("No more events match filters" , style = typography.titleLarge, fontWeight = FontWeight.Bold)
         Spacer(modifier = Modifier.height(120.dp))
     }
     // creates the top bar for the home page (I think might be erroneous with the row below
     Box(
         modifier = Modifier
-            .background(Color.Black)
+            .background(color = colorScheme.primaryContainer)
             .size(width = 450.dp, height = 100.dp)
             .padding(horizontal = 8.dp),
         )
@@ -314,50 +291,50 @@ fun HomeScreen(modifier: Modifier = Modifier, tags: MutableList<Check>) {
                 Button(onClick = { expanded.value = true }) {
                     // displays selected day on the button
                     if (selectedView == 0) {
-                        Text(today.format(formatter))
+                        Text(today.format(formatter), style = typography.labelLarge)
                     } else if (selectedView == 1) {
-                        Text(tomorrow.format(formatter))
+                        Text(tomorrow.format(formatter), style = typography.labelLarge)
                     } else if (selectedView == 2) {
-                        Text(twodays.format(formatter))
+                        Text(twodays.format(formatter), style = typography.labelLarge)
                     } else if (selectedView == 3) {
-                        Text(threedays.format(formatter))
+                        Text(threedays.format(formatter), style = typography.labelLarge)
                     } else if (selectedView == 4) {
-                        Text(fourdays.format(formatter))
+                        Text(fourdays.format(formatter), style = typography.labelLarge)
                     } else if (selectedView == 5) {
-                        Text(fivedays.format(formatter))
+                        Text(fivedays.format(formatter), style = typography.labelLarge)
                     } else {
-                        Text(sixdays.format(formatter))
+                        Text(sixdays.format(formatter), style = typography.labelLarge)
                     }
                 }
                 // creates dropdown menu when button is clicked
                 DropdownMenu(
                     expanded = expanded.value,
                     onDismissRequest = { expanded.value = false }) {
-                    DropdownMenuItem(text = { Text(today.format(formatter)) }, onClick = {
+                    DropdownMenuItem(text = { Text(today.format(formatter), style = typography.labelLarge) }, onClick = {
                         selectedView = 0
                         expanded.value = false
                     })
-                    DropdownMenuItem(text = { Text(tomorrow.format(formatter)) }, onClick = {
+                    DropdownMenuItem(text = { Text(tomorrow.format(formatter), style = typography.labelLarge) }, onClick = {
                         selectedView = 1
                         expanded.value = false
                     })
-                    DropdownMenuItem(text = { Text(twodays.format(formatter)) }, onClick = {
+                    DropdownMenuItem(text = { Text(twodays.format(formatter), style = typography.labelLarge) }, onClick = {
                         selectedView = 2
                         expanded.value = false
                     })
-                    DropdownMenuItem(text = { Text(threedays.format(formatter)) }, onClick = {
+                    DropdownMenuItem(text = { Text(threedays.format(formatter), style = typography.labelLarge) }, onClick = {
                         selectedView = 3
                         expanded.value = false
                     })
-                    DropdownMenuItem(text = { Text(fourdays.format(formatter)) }, onClick = {
+                    DropdownMenuItem(text = { Text(fourdays.format(formatter), style = typography.labelLarge) }, onClick = {
                         selectedView = 4
                         expanded.value = false
                     })
-                    DropdownMenuItem(text = { Text(fivedays.format(formatter)) }, onClick = {
+                    DropdownMenuItem(text = { Text(fivedays.format(formatter), style = typography.labelLarge) }, onClick = {
                         selectedView = 5
                         expanded.value = false
                     })
-                    DropdownMenuItem(text = { Text(sixdays.format(formatter)) }, onClick = {
+                    DropdownMenuItem(text = { Text(sixdays.format(formatter), style = typography.labelLarge) }, onClick = {
                         selectedView = 6
                         expanded.value = false
                     })
@@ -371,7 +348,7 @@ fun HomeScreen(modifier: Modifier = Modifier, tags: MutableList<Check>) {
                 ) {
                     // creates tags menu
                     Button(onClick = { expanded2.value = true }) {
-                        Text("Tags")
+                        Text("Tags", style = typography.labelLarge)
                     }
                     DropdownMenu(
                         expanded = expanded2.value,


### PR DESCRIPTION
In this PR, I fixed the issue where if you have a set of filters via tags on the homepage and then favorite an event, it keeps the tags filtered and doesn't clear them on favoriting. Additionally, I refactored the homepage UI to be easier to change in the future, color scheme or theme-wise, by refactoring to color scheme and typography variables.