### PR TITLE
Fix otp verification async bug by awaiting bcrypt

### DIFF
--- a/src/backend/api/utils.cjs
+++ b/src/backend/api/utils.cjs
@@ -199,10 +199,9 @@ async function otpFileCheck(filename, email, code) {
             // OTP code is valid if
             // - the code entered matches properly
             // - it is before the expiration date
-            return_value = (
-                bcrypt.compare(code, entry.hashedCode) &&
-                now <= expiry
-            );
+            const code_match = await bcrypt.compare(code, entry.hashedCode);
+            const not_expired = now <= expiry;
+            return_value = code_match && not_expired;
         }
 
         // If the return value is true, delete that row from the database -- they


### PR DESCRIPTION
This PR fixes an OTP bug that Anthony identified.

The solution is just to make sure to `await` when we compare the code, otherwise it returns true by default because a non-evaluated Promise is truthy. Javascript moment.