### PR TITLE
Connect Authorized Login/Signup Process with API 

### DIFF
--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/AccountEntity.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/AccountEntity.kt
@@ -26,12 +26,12 @@ data class AccountEntity(
     val accountid: Int,
     val account_name: String,
     val email: String,
-    val profile_picture: String,
-    val favorited_events: List<Int>,
-    val drafted_events: List<Int>,
-    val favorited_tags: List<String>,
-    val notified_events: List<Int>,
-    val account_description: String,
+    val profile_picture: String?,
+    val favorited_events: List<Int>?,
+    val drafted_events: List<Int>?,
+    val favorited_tags: List<String>?,
+    val notified_events: List<Int>?,
+    val account_description: String?,
     val account_role: Int,
     val is_followed: Boolean = false
 )

--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/ApiData.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/ApiData.kt
@@ -30,3 +30,12 @@ data class VerifyRequest(
     val email: String,
     val code: String
 )
+
+/**
+ * Data object of info sent to refresh Tokens
+ */
+data class TokenRefreshResponse(
+    val message: String,
+    val refresh_token: String,
+    val access_token: String
+)

--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/ApiModel.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/ApiModel.kt
@@ -26,4 +26,7 @@ interface ApiModel {
     @POST("user/verify")
     suspend fun verifyOTP(@Body request: VerifyRequest): Response<AuthResponse>
 
+    // Async function to get user info given an access token
+    @GET("user/data")
+    suspend fun getUserData(@retrofit2.http.Header("Authorization") token: String): Response<User>
 }

--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/ApiModel.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/ApiModel.kt
@@ -3,6 +3,7 @@ package com.example.myapplication
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.Header
 import retrofit2.http.POST
 
 
@@ -28,5 +29,9 @@ interface ApiModel {
 
     // Async function to get user info given an access token
     @GET("user/data")
-    suspend fun getUserData(@retrofit2.http.Header("Authorization") token: String): Response<User>
+    suspend fun getUserData(@Header("Authorization") token: String): Response<User>
+
+    // Async function to refresh auth tokens
+    @POST("user/token-refresh")
+    suspend fun refreshToken(@Header("Authorization") refreshToken: String): Response<TokenRefreshResponse>
 }

--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/AppNavigation.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/AppNavigation.kt
@@ -14,6 +14,9 @@ import screens.LoginScreen
 import screens.SignupScreen
 import screens.WelcomeScreen
 import android.content.Context
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Alignment
 
 /**
  * A composable function that is utilized for smooth navigation through login/signup process

--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/AppNavigation.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/AppNavigation.kt
@@ -66,19 +66,17 @@ fun AppNavigation(
             }
         }
         composable(
-            "verification/{email}/{flag}/{username}",
+            "verification/{email}/{flag}",
             arguments = listOf(
-                navArgument("username") { type = NavType.StringType },
                 navArgument("email") { type = NavType.StringType },
                 navArgument("flag"){ type = NavType.BoolType },
 
             )
         ) { backStackEntry ->
-            val username = backStackEntry.arguments?.getString("username") ?: ""
             val email = backStackEntry.arguments?.getString("email") ?: ""
             val flag = backStackEntry.arguments?.getBoolean("flag") ?: false
 
-            EmailVerificationScreen(email, flag, username, navController = navController)
+            EmailVerificationScreen(email, flag, navController = navController)
         }
     }
 }

--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/AppRepository.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/AppRepository.kt
@@ -90,11 +90,11 @@ object AppRepository {
             // Modify the favorited_events list
             val updatedFavorites = if (isFavorited) {
                 // If event is favorited we add the id to our accounts list of favorited events
-                currentAccount.favorited_events + eventId
+                currentAccount.favorited_events?.plus(eventId)
             } else {
                 // If the event has been unfavorited we remove the id from our accounts list of
                 // favorited events
-                currentAccount.favorited_events - eventId
+                currentAccount.favorited_events?.minus(eventId)
             }
 
             // Make new account instance with the new favorited events
@@ -192,14 +192,14 @@ fun AccountEntity.toUser(): User = User(
     accountid = this.accountid,
     account_name = this.account_name,
     email = this.email,
-    profile_picture = this.profile_picture,
-    favorited_events = this.favorited_events,
-    drafted_events = this.drafted_events,
-    favorited_tags = this.favorited_tags,
-    account_description = this.account_description,
+    profile_picture = this.profile_picture?: "",
+    favorited_events = this.favorited_events?: emptyList(),
+    drafted_events = this.drafted_events?: emptyList(),
+    favorited_tags = this.favorited_tags?: emptyList(),
+    account_description = this.account_description?: "",
     account_role = this.account_role,
     is_followed = this.is_followed,
-    notified_events = this.notified_events
+    notified_events = this.notified_events?: emptyList()
 )
 
 /**
@@ -209,12 +209,12 @@ fun User.toAccountEntity(): AccountEntity = AccountEntity(
     accountid = this.accountid,
     account_name = this.account_name,
     email = this.email,
-    profile_picture = this.profile_picture,
-    favorited_events = this.favorited_events,
-    drafted_events = this.drafted_events,
-    favorited_tags = this.favorited_tags,
-    account_description = this.account_description,
+    profile_picture = this.profile_picture?: "",
+    favorited_events = this.favorited_events?: emptyList(),
+    drafted_events = this.drafted_events?: emptyList(),
+    favorited_tags = this.favorited_tags?: emptyList(),
+    account_description = this.account_description?: "",
     account_role = this.account_role,
     is_followed = this.is_followed,
-    notified_events = this.notified_events
+    notified_events = this.notified_events?: emptyList()
 )

--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/DataStoreSettings.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/DataStoreSettings.kt
@@ -142,5 +142,14 @@ object DataStoreSettings {
         return context.dataStore.data.map { it[LAST_SYNC_TIME] }
     }
 
+    /**
+     * Clears all stored preferences
+     * @param context current context our  app is running
+     */
+    suspend fun clearUserSession(context: Context) {
+        context.dataStore.edit { preferences ->
+            preferences.clear()
+        }
+    }
 
 }

--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/MainActivity.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/MainActivity.kt
@@ -2,6 +2,7 @@ package com.example.myapplication
 
 import android.os.Build
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.annotation.RequiresApi
@@ -10,6 +11,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.lifecycle.lifecycleScope
 import com.example.myapplication.ui.theme.MyApplicationTheme
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -66,6 +68,40 @@ class MainActivity : ComponentActivity() {
             if (accountId != null) {
                 // Sets our current active account in the repo to the stored account value
                 AppRepository.setCurrentAccountById(accountId)
+            }
+
+            // We get our refresh token or a null value
+            val refreshToken = DataStoreSettings.getRefreshToken(applicationContext).firstOrNull()
+
+            // We check that the refresh token is none null
+            if (!refreshToken.isNullOrEmpty()) {
+                try {
+                    // Make a refreshToken call to our API
+                    val refreshResponse = RetrofitApiClient.apiModel.refreshToken("Bearer $refreshToken")
+
+                    // If it is successful a 403 error would mean we don't have a refreshToken
+                    if (refreshResponse.isSuccessful) {
+                        // Get new tokens
+                        val newAccessToken = refreshResponse.body()?.access_token
+                        val newRefreshToken = refreshResponse.body()?.refresh_token
+
+                        // So long as they are non-null we set the tokens
+                        if (newAccessToken != null && newRefreshToken != null) {
+                            // Save new tokens
+                            DataStoreSettings.setAccessToken(applicationContext, newAccessToken)
+                            DataStoreSettings.setRefreshToken(applicationContext, newRefreshToken)
+                            // Tokens refreshed successfully! User stays logged in.
+                        }
+                    } else {
+                        // Refresh token invalid or expired
+                        DataStoreSettings.clearUserSession(applicationContext)
+                    }
+                } catch (e: Exception) {
+                    // Network error of some sort likely unable to leave the app (this is allowed
+                    // since we have the cached events so long as they have been updated within 3hrs so we
+                    // won't clear session
+                    Toast.makeText(applicationContext, "No internet connection. You are offline.", Toast.LENGTH_LONG).show()
+                }
             }
 
             setContent {

--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/screens/EmailVerificationScreen.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/screens/EmailVerificationScreen.kt
@@ -54,7 +54,7 @@ import com.example.myapplication.toAccountEntity
  * @param navController used to move through the app
  */
 @Composable
-fun EmailVerificationScreen(email: String, flag: Boolean, username: String, navController: NavController, modifier: Modifier = Modifier) {
+fun EmailVerificationScreen(email: String, flag: Boolean, navController: NavController, modifier: Modifier = Modifier) {
     // The code the user inputs
     var codeInput by remember { mutableStateOf("") }
     // General error messages
@@ -174,6 +174,15 @@ fun EmailVerificationScreen(email: String, flag: Boolean, username: String, navC
                                         DataStoreSettings.setLoggedInAccountId(context, accountEntity.accountid)
                                         // Sets storage preference logged in to true
                                         DataStoreSettings.setLoggedIn(context, true)
+                                        // If this is a login
+                                        if(!flag){
+                                            // Gets the current time
+                                            val now = System.currentTimeMillis()
+                                            // Syncs from API
+                                            AppRepository.syncFromApi()
+                                            // Sets the new LastSyncTime to now
+                                            DataStoreSettings.setLastSyncTime(context, now)
+                                        }
                                         // Navigates to main page
                                         navController.navigate("main") {
                                             popUpTo(0) { inclusive = true }
@@ -258,5 +267,5 @@ fun EmailVerificationScreen(email: String, flag: Boolean, username: String, navC
 @Preview (showBackground = true)
 @Composable
 fun EmailVerificationScreenPreview(){
-    EmailVerificationScreen(modifier= Modifier, username = "user", email= "", flag = true, navController = rememberNavController())
+    EmailVerificationScreen(modifier= Modifier, email= "", flag = true, navController = rememberNavController())
 }

--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/screens/EmailVerificationScreen.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/screens/EmailVerificationScreen.kt
@@ -133,8 +133,8 @@ fun EmailVerificationScreen(email: String, flag: Boolean, navController: NavCont
             // This is our verify button
             Button(onClick = {
                 coroutineScope.launch {
-                    // Checks that the code input is at least 6 characters long
-                    if (codeInput.length < 6) {
+                    // Checks that the code input is 6 characters long
+                    if (codeInput.length == 6) {
                         errMsg = "Please enter 6-digit code"
                         errCode = true
                         return@launch // Escapes launch due to missing username

--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/screens/LoginScreen.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/screens/LoginScreen.kt
@@ -171,7 +171,7 @@ fun LoginScreen(modifier: Modifier, navController: NavController) {
                             // Assess if the request and validation of login was successful if so
                             // nav to main if not show login failure.
                             if (emailResponse.isSuccessful) {
-                            navController.navigate("verification/${email}/${signUp}/str") {
+                            navController.navigate("verification/${email}/${signUp}") {
                                 popUpTo(0) { inclusive = true }
                                 launchSingleTop = true
                             }

--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/screens/SettingsScreen.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/screens/SettingsScreen.kt
@@ -292,9 +292,8 @@ fun SettingsScreen(modifier: Modifier = Modifier,
             Button (
                 onClick = {  // Sets our logged in state to false
                     coroutineScope.launch{
-                        DataStoreSettings.setLoggedIn(context, false)
-                        DataStoreSettings.setLoggedInAccountId(context, 0)
-                        // 0 will be our effective null state of account since no account will have accountID 0
+                        // This resets user preferences to default states
+                        DataStoreSettings.clearUserSession(context)
                     }
                     navController.navigate("welcome"){ // takes us to the welcome screen
                         popUpTo(0){inclusive = true} // pops the back stack

--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/screens/SignupScreen.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/screens/SignupScreen.kt
@@ -208,7 +208,7 @@ fun SignupScreen(modifier: Modifier, navController: NavController) {
                             // Assess if the request and if the email was available
                             if (response.isSuccessful) {
                             // Sets our logged in state to true
-                            navController.navigate("verification/${email}/${signUp}/${username}") {
+                            navController.navigate("verification/${email}/${signUp}") {
                                 popUpTo(0) { inclusive = true }
                                 launchSingleTop = true
                             }


### PR DESCRIPTION
DONE:
- Added a way to clear all preference states
-  Logins and Signups now use the token system almond set up
- We sync events with the api on login to ensure any favorited events a user might have display as such on the first login on the device.
- In theory we handle refresh tokens logging user out if expired (could use more error handling but I think it should work)
- We are pretty well linked beyond being able to update the API with our changes like new favorited events, new notified events (still need to setup checking all notified events will likely be an exact replica of the favorite events process just with is_notified as the boolean) and or a username change. After that I believe all facets will be connected.