### PR TITLE
Check if body parameters exist more rigorously

### DIFF
--- a/src/backend/api/api.cjs
+++ b/src/backend/api/api.cjs
@@ -21,6 +21,8 @@ var https_server = null;
 function run() {
   // Load environment vars from .env file
   require('dotenv').config();
+  const ACCESS_JWT = process.env.ACCESS_TOKEN_SECRET
+  const REFRESH_JWT = process.env.REFRESH_TOKEN_SECRET
 
   // Create the app that we will serve
   const app = express();
@@ -83,20 +85,6 @@ function run() {
   app.get('/', routeShowOnline);
 
   /*
-   * JWT VERIFICATION
-   *
-   * These functions are basically aliases for middlewareVerifyJWT, but each
-   * of them has it verify using a different secret. This lets us verify either
-   * an auth key or a refresh key.
-   */
-  const middlewareVerifyAuth = (req, res, next) => {
-    middlewareVerifyJWT(process.env.ACCESS_TOKEN_SECRET, req, res, next);
-  }
-  const middlewareVerifyRefresh = (req, res, next) => {
-    middlewareVerifyJWT(process.env.REFRESH_TOKEN_SECRET, req, res, next);
-  }
-
-  /*
    * EVENTS ROUTES
    *
    * TODO: when frontends implement JWTs, these routes should become protected.
@@ -118,15 +106,36 @@ function run() {
 
   // Login and signups will be done through POST requests, which is because you
   // have to send information and there's the metaphor of creating something new.
-  app.post('/user/login', user.routeSendOTP);
-  app.post('/user/signup', user.routeSignUpNewUser);
-  
+  app.post('/user/login',
+    [middlewareBodyExists('email')],
+    user.routeSendOTP
+  );
+  app.post(
+    '/user/signup',
+    [
+      middlewareBodyExists('email'),
+      middlewareBodyExists('username'),
+    ],
+    user.routeSignUpNewUser
+  );
+
   // Resend an OTP code by POSTing the email you need it sent to.
-  app.post('/user/resend-otp', user.routeSendOTP);
+  app.post(
+    '/user/resend-otp',
+    [middlewareBodyExists('email')],
+    user.routeSendOTP
+  );
 
   // OTP code verification also through a POST request. If successful, it will
   // send back the needed authentication tokens.
-  app.post('/user/verify', user.routeVerifyOTP);
+  app.post(
+    '/user/verify',
+    [
+      middlewareBodyExists('email'),
+      middlewareBodyExists('code')
+    ],
+    user.routeVerifyOTP
+  );
 
   /*
    * USER DATA ROUTES
@@ -136,22 +145,63 @@ function run() {
    */
 
   // When logged in, you can refresh your own tokens whenever needed.
-  app.post('/user/token-refresh', middlewareVerifyRefresh, user.routeRefreshTokens);
+  app.post(
+    '/user/token-refresh',
+    [middlewareVerifyJWT(REFRESH_JWT)],
+    user.routeRefreshTokens
+  );
 
   // Get your own data by requesting it with a GET request.
-  app.get('/user/data', middlewareVerifyAuth, user.routeGetUserData);
+  app.get(
+    '/user/data',
+    [middlewareVerifyJWT(ACCESS_JWT)],
+    user.routeGetUserData
+  );
 
   // Favorited events: GET (read) and PUT (write)
-  app.get('/user/events/favorited', middlewareVerifyAuth, user.routeGetFavorited);
-  app.put('/user/events/favorited', middlewareVerifyAuth, user.routePutFavorited);
+  app.get(
+    '/user/events/favorited',
+    [middlewareVerifyJWT(ACCESS_JWT)],
+    user.routeGetFavorited
+  );
+  app.put(
+    '/user/events/favorited',
+    [
+      middlewareBodyExists('favorited_events'),
+      middlewareVerifyJWT(ACCESS_JWT)
+    ],
+    user.routePutFavorited
+  );
 
   // Notified events: GET (read) and PUT (write)
-  app.get('/user/events/notified', middlewareVerifyAuth, user.routeGetNotified);
-  app.put('/user/events/notified', middlewareVerifyAuth, user.routePutNotified);
+  app.get(
+    '/user/events/notified',
+    [middlewareVerifyJWT(ACCESS_JWT)],
+    user.routeGetNotified
+  );
+  app.put(
+    '/user/events/notified',
+    [
+      middlewareBodyExists('notified_events'),
+      middlewareVerifyJWT(ACCESS_JWT)
+    ],
+    user.routePutNotified
+  );
 
   // Username: GET (read) and PUT (write)
-  app.get('/user/username', middlewareVerifyAuth, user.routeGetUsername);
-  app.put('/user/username', middlewareVerifyAuth, user.routePutUsername);
+  app.get(
+    '/user/username',
+    [middlewareVerifyJWT(ACCESS_JWT)],
+    user.routeGetUsername
+  );
+  app.put(
+    '/user/username',
+    [
+      middlewareBodyExists('username'),
+      middlewareVerifyJWT(ACCESS_JWT)
+    ],
+    user.routePutUsername
+  );
 }
 
 /**
@@ -194,77 +244,99 @@ function routeShowOnline(_req, res) {
 }
 
 /**
- * Middleware to verify a JWT with an arbitrary secret key.
+ * Generate a middleware that makes sure the request body contains a name.
  * 
- * Verifies the JWT token contained in the `Authorization` header of the request. On any
- * error, responds to the request with failure.
- * 
- * On success, the `req.email` variable will be set corresponding to the
- * authorized user, which the route using this middleware will be able to access.
- * 
- * > Based on https://www.slingacademy.com/article/authentication-authorization-expressjs-jwt/.
- * 
- * @param {*} token_secret  Secret key of the JWT token to verify.
- * @param {*} req  Express request object, contains the headers.
- * @param {*} res  Express response object.
- * @param {*} next  Express callback. Since this is a middleware, `next()` will
- * call the function *after* the middleware.
+ * @param {string} name  The required name.
+ * @returns  An express middleware that takes in `(req, res, next)`. 
+ * It rejects the request if the body does NOT contain the specified `name`, 
+ * and otherwise allows the request to continue.
  */
-function middlewareVerifyJWT(token_secret, req, res, next) {
-  // Get the contents of the Authorization header sent along with the request
-  const authHeader = req.get('Authorization');
+function middlewareBodyExists(name) {
+  // Construct a route function that will check that `name`
+  // exists within the body of the request.
+  return (req, res, next) => {
+    // If the request has no body, or if the body does not contain the right item,
+    // respond with failure to the request immediately.
+    if (!(req.body && req.body[name])) {
+      res.status(400).json({
+        'error': `Bad request`,
+        'message': `Request body must contain ${name}.`
+      });
+      return;
+    }
 
-  // Attempt to get the token out of the header. Two important details:
-  // 
-  // - authHeader will be undefined if it was not included, so we need to use
-  //   `authHeader &&` to avoid an error and have it eval to undefined.
-  // 
-  // - we expect the contents to be `Bearer {TOKEN}`, which is why we split
-  //   and take the second element. if there is no second element (e.g. malformed
-  //   input), the expression will also evaluate to undefined.
-  const token = authHeader && authHeader.split(' ')[1];
-
-  // If token is undefined, that means we couldn't read it (see above).
-  // When this happens, respond HTTP 401 which tells the user they are not authorized
-  if (!token) {
-    res.status(401).json({
-      'error': 'Token required',
-      'message': 'An authorization token is required, but it was not provided.'
-    });
-    return;
+    // Otherwise, the request can go forward! Yay!
+    next();
   }
+}
 
-  // Use the jwt library to verify. The callback we provide will be run async
-  jwt.verify(token, token_secret, async (err, payload) => {
-    // If JWT verify fails, stop the request now and return a 403 error.
-    // That error is generally agreed to mean "you need to reauthorize".
-    if (err) {
-      res.status(403).json({
-        'error': 'Invalid or expired token',
-        'message': `The authorization token provided was not valid, \
+/**
+ * Create a middleware that verifies a specific JWT token.
+ * 
+ * @param {string} token_secret  Secret key of the JWT token to verify.
+ * @returns  An express middleware that takes in `(req, res, next)`.
+ * It rejects the request if the JWT does not verify or the auth header is malformed,
+ * and sets `req.email` and lets the response continue on success.
+ */
+function middlewareVerifyJWT(token_secret) {
+  // Construct a request function that will check that token_secret.
+  // Based on https://www.slingacademy.com/article/authentication-authorization-expressjs-jwt/.
+  return async (req, res, next) => {
+    // Get the contents of the Authorization header sent along with the request.
+    const authHeader = req.get('Authorization');
+
+    // Attempt to get the token out of the header. Two important details:
+    // 
+    // - authHeader will be undefined if it was not included, so we need to use
+    //   `authHeader &&` to avoid an error and have it eval to undefined.
+    // 
+    // - we expect the contents to be `Bearer {TOKEN}`, which is why we split
+    //   and take the second element. if there is no second element (e.g. malformed
+    //   input), the expression will also evaluate to undefined.
+    const token = authHeader && authHeader.split(' ')[1];
+
+    // If token is undefined, that means we couldn't read it (see above).
+    // When this happens, respond HTTP 401 which tells the user they are not authorized
+    if (!token) {
+      res.status(401).json({
+        'error': 'Token required',
+        'message': 'An authorization token is required, but it was not provided.'
+      });
+      return;
+    }
+
+    // Use the jwt library to verify. The callback we provide will be run async
+    jwt.verify(token, token_secret, async (err, payload) => {
+      // If JWT verify fails, stop the request now and return a 403 error.
+      // That error is generally agreed to mean "you need to reauthorize".
+      if (err) {
+        res.status(403).json({
+          'error': 'Invalid or expired token',
+          'message': `The authorization token provided was not valid, \
 or has expired. Please request a new token.`
-      });
-      return;
-    }
+        });
+        return;
+      }
 
-    // Ensure that an account exists with that email. This makes sure we're okay
-    // if someone deletes their accounts but continues trying to make requests.
-    const email = payload.email;
-    const account = await db.getAccountByEmail(email);
-    if (account === undefined) {
-      res.status(404).json({
-        'error': 'No such user',
-        'message': `You are verified with email ${email}, but no user exists with \
+      // Ensure that an account exists with that email. This makes sure we're okay
+      // if someone deletes their accounts but continues trying to make requests.
+      const email = payload.email;
+      const account = await db.getAccountByEmail(email);
+      if (account === undefined) {
+        res.status(404).json({
+          'error': 'No such user',
+          'message': `You are verified with email ${email}, but no user exists with \
 that address.`
-      });
-      return;
-    }
+        });
+        return;
+      }
 
-    // Store the email from the payload for access,
-    // then call `next()` to make the route using this middleware run.
-    req.email = email;
-    next()
-  });
+      // Store the email from the payload for access,
+      // then call `next()` to make the route using this middleware run.
+      req.email = email;
+      next()
+    });
+  }
 }
 
 // run the server when we are run, export otherwise.

--- a/src/backend/api/api.cjs
+++ b/src/backend/api/api.cjs
@@ -64,6 +64,21 @@ function run() {
       });
   }
 
+  /*****************************************************************************
+   * SETTING UP ROUTES.                                                        *
+   *****************************************************************************
+   *
+   * Each route has 4 parts. They look like this.
+   *
+   * `app.put('a', [b, c], d);`
+   * - put means that this is a PUT request, rather than a GET or something else
+   * - 'a' is the URI, it's the end of the URL to access that route--what frontends connect to.
+   * - b and c are middlewares. they are functions that run on the request to
+   *   validate it before going to the main request. they can reject the request
+   *   early if it is invalid.
+   * - d is the request function, it runs last and handles the main request.
+   */
+
   // Default route just shows the API is online.
   app.get('/', routeShowOnline);
 

--- a/src/backend/api/routes/user.cjs
+++ b/src/backend/api/routes/user.cjs
@@ -29,15 +29,8 @@ async function routeGetUserData(req, res, _next) {
  * @param {*} _next  Express error handler for async, unused.
  */
 async function routeSendOTP(req, res, _next) {
-  // Make sure email is included in the body
+  // Get email from the body, we know it is there thanks to the middleware
   const email = req.body.email;
-  if (email === undefined) {
-    res.status(400).json({
-      'error': 'No email',
-      'message': 'An email must be provided in the body of the request.'
-    })
-    return;
-  }
 
   // Make sure the user already exists. If it does not, return a HTTP 404 error.
   // That signifies "resource not found", which is appropriate here.
@@ -69,29 +62,12 @@ async function routeSendOTP(req, res, _next) {
  * @param {*} _next  Error handler function for async (unused)
  */
 async function routeSignUpNewUser(req, res, _next) {
-  // Make sure the request provided a username. If it does not,
-  // return an HTTP 400 which indicates a badly-formed request.
+  // Get username and email from the request, which we can assume exists thanks to the middleware
   const username = req.body.username;
-  if (username === undefined) {
-    res.status(400).json({
-      'error': 'No username',
-      'message': 'A username must be provided in the body of the request.'
-    })
-    return;
-  }
-
-  // Do the same check to make sure an email is included in the request body.
   const email = req.body.email;
-  if (email === undefined) {
-    res.status(400).json({
-      'error': 'No email',
-      'message': 'An email must be provided in the body of the request.'
-    });
-    return;
-  }
 
   // Make sure the email is a grinnell email. If it does not, respond with
-  // an appropriate error. 400 again.
+  // an appropriate error. 400 for "bad request"
   if (!email.endsWith('@grinnell.edu')) {
     res.status(400).json({
       'error': 'Invalid email',
@@ -181,23 +157,9 @@ function generateUserTokens(email) {
  */
 async function routeVerifyOTP(req, res, _next) {
   // Get the email and OTP sent from the body,
-  // and make sure they were actually sent.
+  // we can assume they exist thanks to the middleware.
   const email = req.body.email;
   const code = req.body.code;
-  if (email === undefined) {
-    res.status(400).json({
-      'error': 'No email',
-      'message': 'Request body must contain email.'
-    });
-    return;
-  }
-  if (code === undefined) {
-    res.status(400).json({
-      'error': 'No code',
-      'message': 'Request body must contain code.'
-    });
-    return;
-  }
 
   // Check the OTP code the user entered against the codes we have stored.
   // If it does not match (wrong code or expired), return the same error with
@@ -249,16 +211,8 @@ async function routeGetFavorited(req, res, _next) {
  * @param {*} next  Express callback function
  */
 async function routePutFavorited(req, res, next) {
-  // Make sure favorited_events is within the body of the request.
-  if (!req.body.favorited_events) {
-    res.status(400).json({
-      'error': 'Bad request',
-      'message': 'Body must include favorited_events array.'
-    });
-    return;
-  }
-
   // Set the favorited_events array of that user, and let that function do the response.
+  // This assumes the body has `favorited_events`, and the middleware makes sure that is true
   await util.userDataSetArray('favorited_events', req, res, next);
 }
 
@@ -289,16 +243,8 @@ async function routeGetNotified(req, res, _next) {
  */
 
 async function routePutNotified(req, res, next) {
-  // Make sure notified_events is within the body of the request.
-  if (!req.body.notified_events) {
-    res.status(400).json({
-      'error': 'Bad request',
-      'message': 'Body must include notified_events array.'
-    });
-    return;
-  }
-
   // Set the notified_events array of that user, and let that function do the response.
+  // This requires the body contain `notified_events`, which we get thanks to the middleware
   await util.userDataSetArray('notified_events', req, res, next);
 }
 
@@ -328,15 +274,8 @@ async function routeGetUsername(req, res, _next) {
  * @param {*} _next  Express callback function, unused
  */
 async function routePutUsername(req, res, _next) {
-  // Make sure username is within the body of the request.
+  // Get new username from the request body, we can assume it exists thanks to the middleware.
   const newUsername = req.body.username;
-  if (newUsername === undefined) {
-    res.status(400).json({
-      'error': 'Bad request',
-      'message': 'Body must include username.'
-    });
-    return;
-  }
 
   // Get the username from the request body, and make sure it's a string.
   if (typeof newUsername !== 'string') {


### PR DESCRIPTION
This PR makes sure we check the body parameters of requests more rigorously.

It does this by creating a middleware (basically a function that verifies a request before it runs) that makes sure the request body contains a key more rigorously--both checking for the key and making sure the request body itself exists. (the difference between a body of `{}` and `undefined`).

This is `middlewareBodyExists`. When you call that, it creates a middleware that verifies that thing.

I also did a simular change to `middlewareVerifyJWT`, to make it take a parameter and construct a new middleware function.