### PR TITLE
Implement Remaining API Connections

### DIFF
--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/ApiData.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/ApiData.kt
@@ -39,3 +39,31 @@ data class TokenRefreshResponse(
     val refresh_token: String,
     val access_token: String
 )
+
+/**
+ * Data object of info sent to update favorited events for a user
+ */
+data class UpdateFavoritesRequest(
+    val favorited_events: List<Int>
+)
+
+/**
+ * Data object of info sent to update notified events for a user
+ */
+data class UpdateNotificationsRequest(
+    val notified_events: List<Int>
+)
+
+/**
+ * Trivial response for message to check a success
+ */
+data class SimpleMessageResponse(
+    val message: String
+)
+
+/**
+ * Data object of info sent to update a username for a user
+ */
+data class UpdateUsernameRequest(
+    val username: String
+)

--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/ApiModel.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/ApiModel.kt
@@ -5,6 +5,7 @@ import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.POST
+import retrofit2.http.PUT
 
 
 /**
@@ -34,4 +35,16 @@ interface ApiModel {
     // Async function to refresh auth tokens
     @POST("user/token-refresh")
     suspend fun refreshToken(@Header("Authorization") refreshToken: String): Response<TokenRefreshResponse>
+
+    // Async function to update the remote databases list of favorited events for a user
+    @PUT("user/events/favorited")
+    suspend fun updateFavorites(@Header("Authorization") token: String, @Body favorites: UpdateFavoritesRequest): Response<SimpleMessageResponse>
+
+    // Async function to update the remote databases list of notified events for a user
+    @PUT("user/events/notified")
+    suspend fun updateNotifications(@Header("Authorization") token: String, @Body notifications: UpdateNotificationsRequest): Response<SimpleMessageResponse>
+
+    // Async function to update the remote databases current username for a user
+    @PUT("user/username")
+    suspend fun updateUsername(@Header("Authorization") token: String, @Body usernameRequest: UpdateUsernameRequest): Response<SimpleMessageResponse>
 }

--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/ApiUtils.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/ApiUtils.kt
@@ -1,0 +1,60 @@
+package com.example.myapplication
+
+import android.content.Context
+import kotlinx.coroutines.flow.first
+import retrofit2.Response
+
+/**
+ * THIS FILE AS A WHOLE: This file is meant to be used for any general utility helper functions
+ * to use to contact the API in a given way.
+ */
+
+/**
+ * Used to safely attempt to make an authorized api call as it handles checking the access token is
+ * valid and if not makes a refresh call for our tokens and then reattempts the api call with the
+ * newly refreshed access token
+ * @param context the current context of the app
+ * @param apiCall the api call you are trying to make
+ * @return the response of the api call
+ */
+suspend fun <T> safeApiCall(context: Context, apiCall: suspend (accessToken: String) -> Response<T>): Response<T> {
+    // We get our accessToken from our storage
+    val accessToken = DataStoreSettings.getAccessToken(context).first()
+    // Try the call with our current access token
+    var response = apiCall("Bearer $accessToken")
+
+    // If we get a 403 error this means we don't have a valid access token or it has expired
+    if (response.code() == 403) {
+        // We get our refreshToken from our storage
+        val refreshToken = DataStoreSettings.getRefreshToken(context).first()
+
+        try {
+            // Make a refresh token call
+            val refreshResponse = RetrofitApiClient.apiModel.refreshToken("Bearer $refreshToken")
+
+            // Assuming this is successful
+            if (refreshResponse.isSuccessful) {
+                // Set our new tokens
+                val newAccessToken = refreshResponse.body()?.access_token
+                val newRefreshToken = refreshResponse.body()?.refresh_token
+
+                // Check that we have tokens we received from the api
+                if (!newAccessToken.isNullOrEmpty() && !newRefreshToken.isNullOrEmpty()) {
+                    // Store the new tokens we received
+                    DataStoreSettings.setAccessToken(context, newAccessToken)
+                    DataStoreSettings.setRefreshToken(context, newRefreshToken)
+
+                    // Try our api call we wanted to make originally again with the new access token
+                    response = apiCall("Bearer $newAccessToken")
+                } // Would just return failing response if these tokens were not received this should
+                // never happen
+            } // This failing would imply that our check on build didn't refresh the token which again shouldn't
+            // not happen not sure what error/how to handle that yet.
+            // This error would be network related and thus we would just want to log the error and
+            // return the response.
+        } catch (e: Exception) {
+            e.printStackTrace() // Log our error
+        }
+    }
+    return response // the response of the outcome ideally of the api call we wanted to make.
+}

--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/AppDao.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/AppDao.kt
@@ -9,13 +9,15 @@ import androidx.room.Dao
 @Dao
 interface AppDao {
 
-    // Event Operations
+    /* EVENTS OPERATIONS */
 
     // Gets you all events in a flow type so data is reactive and sorted by date and time
     @Query("SELECT * FROM events ORDER BY event_date ASC, event_start_time ASC")
     fun getAllEvents(): Flow<List<EventEntity>>
 
-
+    // Deletes events that have expired by a day and returns the number of deleted events
+    @Query("DELETE FROM events WHERE event_date < :currentDate")
+    suspend fun deleteExpiredEvents(currentDate: String): Int
 
     // Gets events by a given id should probably switch this to a flow
     @Query("SELECT * FROM events WHERE eventid = :id")
@@ -45,11 +47,16 @@ interface AppDao {
     @Query("UPDATE events SET is_favorited = :isFavorited WHERE eventid = :eventId")
     suspend fun updateFavoriteStatus(eventId: Int, isFavorited: Boolean)
 
-    // Updates whether an event is favorited or not basically flips the symbol
+    // Updates whether an event is notified or not basically flips the symbol
     @Query("UPDATE events SET is_notification = :isNotification WHERE eventid = :eventId")
     suspend fun updateNotificationStatus(eventId: Int, isNotification: Boolean)
 
-    // Account Operations
+    // Gets the list of eventids in the database
+    @Query("SELECT eventid FROM events")
+    suspend fun getAllEventIds(): List<Int>
+
+    /* ACCOUNT OPERATIONS */
+
     // Upserts an account into the account table
     @Upsert
     suspend fun upsertAccount(account: AccountEntity)

--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/EventCard.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/EventCard.kt
@@ -56,8 +56,6 @@ import java.util.Date
 fun EventCard(event: Event, modifier: Modifier = Modifier) {
     // Boolean to track whether a card is expanded
     val expanded = remember { mutableStateOf(false) }
-    // Boolean to track if card should cause notification
-    val isNotification = remember(event.is_notification) { mutableStateOf(event.is_notification) }
     val context = LocalContext.current
     // Accessing colors from our theme
     val colorScheme = MaterialTheme.colorScheme
@@ -99,14 +97,12 @@ fun EventCard(event: Event, modifier: Modifier = Modifier) {
             ) {
                 // Makes a column within the row to display the name of the event
                 Column(modifier = Modifier.weight(1f)) {
-                    event.event_name.let {
-                        Text(
-                            text = it,
-                            style = typography.titleLarge,
-                            color = colorScheme.onSurface,
-                            fontWeight = FontWeight.Bold
-                        )
-                    }
+                    Text(
+                        text = event.event_name,
+                        style = typography.titleLarge,
+                        color = colorScheme.onSurface,
+                        fontWeight = FontWeight.Bold
+                    )
                     Spacer(modifier = Modifier.height(4.dp))
                     Text(text = "${event.event_date} at ${event.event_time}",
                         style = typography.bodyMedium,
@@ -143,18 +139,17 @@ fun EventCard(event: Event, modifier: Modifier = Modifier) {
                     )
                     // This is our notification icon
                     Icon(
-                        imageVector = if (isNotification.value) Icons.Filled.Notifications else Icons.Outlined.Notifications,
+                        imageVector = if (event.is_notification) Icons.Filled.Notifications else Icons.Outlined.Notifications,
                         contentDescription = "Notification Icon",
                         tint = colorScheme.tertiary,
                         modifier = Modifier
                             .size(40.dp)
                             .clickable {
-                                isNotification.value = !isNotification.value
                                 // This tells our database to update the events notification status
                                 CoroutineScope(Dispatchers.IO).launch {
-                                    AppRepository.toggleNotification(event.eventid, isNotification.value)
+                                    AppRepository.toggleNotification(event.eventid, !event.is_notification)
                                 }
-                                if (isNotification.value){
+                                if (!event.is_notification){
                                     if (getDifferenceInMillis(LocalDateTime.now().toString().toDate("yyyy-MM-dd'T'HH:mm:ss.SSS"),
                                             event.event_end_time.toDate("yyyy-MM-dd'T'HH:mm:ss.SSS")
                                             ) < 0){

--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/MainActivity.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/MainActivity.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.lifecycle.lifecycleScope
 import com.example.myapplication.ui.theme.MyApplicationTheme
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
@@ -129,6 +130,18 @@ class MainActivity : ComponentActivity() {
                         tags = tags.sortedBy { it.label },
                         startDestination = if (isLoggedIn) "main" else "welcome",
                     ) // What screen to launch the app on
+                }
+            }
+            // Background task launched after we set our content
+            launch {
+                // Number of minutes we want to delay to update the remote database
+                val minutes = 1L // Currently it is every minute this can change
+                // Runs indefinitely as a background task
+                while (true) {
+                    // Sets the delay to send in minutes
+                    delay(minutes * 60 * 1000)
+                    // Syncs our current local data with the remote
+                    AppRepository.syncAccountData(context = applicationContext)
                 }
             }
         }

--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/screens/SettingsScreen.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/screens/SettingsScreen.kt
@@ -112,7 +112,7 @@ fun SettingsScreen(modifier: Modifier = Modifier,
 
             Spacer(modifier = modifier.weight(1f))
 
-            // This is the icon button for switch an account
+           /* // This is the icon button for switch an account
             IconButton(
                 onClick = { /* TODO handle switch account */ },
                 modifier = modifier.padding(end = 8.dp)
@@ -127,7 +127,7 @@ fun SettingsScreen(modifier: Modifier = Modifier,
                         tint = colorScheme.primary
                     )
                 }
-            }
+            }*/
         }
 /* This is commented out for the time being as we have the profile picture as a stretch goal.
         Box(
@@ -244,6 +244,8 @@ fun SettingsScreen(modifier: Modifier = Modifier,
                                 AppRepository.upsertAccount(updatedAccount.toAccountEntity())
                                 // Sets our current active account to the given account
                                 AppRepository.setCurrentAccountById(updatedAccount.accountid)
+                                // Sends our updated username to the remote database
+                                AppRepository.syncUsername(newUsername)
                                 // Closes the editing dialog
                                 showEditDialog = false
                             }


### PR DESCRIPTION
DONE:
- Setup the routes to make the put requests for favorited events, notified events, and updated username
- I implemented a utility function to make safe API calls specifically regarding an expired access token
- Implemented a query to delete expired events that also removes them from our users list of favorited events
- Changed Event Cards to use the event is notification state instead of the mutable state to ensure it updates properly when we rebuild the app for persistence.
- Launch a background task to update the remote with new local info (currently set to once a minute, can be slowed down)
- Settings page now updates the remote username
- Pull to refresh and sync local information with the remote database.
- Commented out switch account icon