### PR TITLE
Allow closing of DB connection

### DIFF
--- a/src/backend/api/api.cjs
+++ b/src/backend/api/api.cjs
@@ -231,6 +231,9 @@ function close() {
       }
     });
   }
+
+  // close connection to the database
+  db.end();
 }
 
 /**

--- a/src/backend/db_connect.js
+++ b/src/backend/db_connect.js
@@ -20,6 +20,13 @@ const pool = mysql.createPool({
 }).promise()
 
 /**
+ * End the connection to the database pool.
+ */
+function end() {
+    pool.end();
+}
+
+/**
  * insertEventsFromScrape
  * 
  * uses scraped json file to fill events into database
@@ -310,6 +317,7 @@ if (require.main === module) {
 } else {
     // File is being used as a module. Export it.
     module.exports = {
+        end,
         createAccount,
         dropExpiredEvents,
         getAccount,


### PR DESCRIPTION
# Changes

There isn't much code in this PR. It lets you close the database connection by calling the `end()` function exported from `db_connect.js`, which will allow things like tests to exit. It could potentially be applied to event scraping, but I'm not certain on that.

# Manual Testing

One major concern I was aware of is this: If I close my connection to the database, will it break another connection?

I tested this in two ways.

## In two different processes

I ran two copies of the API, but modified the code of one to run on a different port and close after 1 second of time. Then, I checked if the API that didn't automatically exit could still connect to the database. It could.

## Within the same process

I ran this program with my changes.

```
const main = async () => {
    const db1 = require('./db_connect');
    const db2 = require('./db_connect');

    db1.end();

    const events = await db2.getEvents();
    console.log(events);

    db2.end();
};

main();
```

This **has an error**: the connection is literally the same one, and closing the connection to db1 is the same as the one to db2.

Question: Is this going to be a problem? I can fix this, but it will be more invasive and require changes that go beyond.