### PR TITLE
Refactor user login routes under "session" grouping

### DIFF
--- a/docs/api-v1.yaml
+++ b/docs/api-v1.yaml
@@ -6,15 +6,17 @@ servers:
   - url: https://node16049-csc324--spring2025.us.reclaim.cloud/
 tags:
   - name: events
-    description: Getting calendar events. 
+    description: Retrieve calendar events. 
+  - name: session
+    description: Session login and authorization.
   - name: user
-    description: Logging in and changing user settings.
+    description: Get and modify logged-in user settings.
 paths:
-  /user/login:
+  /session/login:
     post:
       tags:
-        - user
-      summary: Log in.
+        - session
+      summary: Log into existing account.
       description: |
         Log in an existing user, which will send a one-time code to their email. 
         
@@ -66,11 +68,11 @@ paths:
                     example: No email
                   message:
                     example: An email must be provided in the body of the request.
-  /user/signup:
+  /session/signup:
     post:
       tags:
-        - user
-      summary: Sign up.
+        - session
+      summary: Sign up for new account.
       description: |
         Sign up a new user account. 
         
@@ -115,10 +117,10 @@ paths:
                     example: Invalid username
                   message:
                     example: Username must not contain the sequences '_.', '._', '..', or '__'.
-  /user/resend-otp:
+  /session/resend-code:
     post:
       tags:
-        - user
+        - session
       summary: Resend OTP code for login/signup.
       description: |
         Resend an OTP code to a user, such as if they do not recieve their code when logging in.
@@ -167,10 +169,10 @@ paths:
                     example: No email
                   message:
                     example: An email must be provided in the body of the request.
-  /user/verify:
+  /session/verify:
     post:
       tags:
-        - user
+        - session
       summary: Verify recieved OTP code.
       description: |
         Verify the OTP code that has been sent to a user's email. If the code is correct and has not expired, an authorization and a refresh token will be sent back.
@@ -240,11 +242,11 @@ paths:
           $ref: '#/components/responses/InvalidToken'
         '404':
           $ref: '#/components/responses/NoSuchUser'
-  /user/token-refresh:
+  /session/refresh:
     post:
       tags:
-        - user
-      summary: Refresh user tokens when logged in.
+        - session
+      summary: Refresh tokens when already logged in.
       description: Refresh user tokens using a refresh token, which you can only get by logging in previously.
       security:
         - refresh_token: []

--- a/src/backend/api/api.cjs
+++ b/src/backend/api/api.cjs
@@ -106,12 +106,12 @@ function run() {
 
   // Login and signups will be done through POST requests, which is because you
   // have to send information and there's the metaphor of creating something new.
-  app.post('/user/login',
+  app.post('/session/login',
     [middlewareBodyExists('email')],
     user.routeSendOTP
   );
   app.post(
-    '/user/signup',
+    '/session/signup',
     [
       middlewareBodyExists('email'),
       middlewareBodyExists('username'),
@@ -121,7 +121,7 @@ function run() {
 
   // Resend an OTP code by POSTing the email you need it sent to.
   app.post(
-    '/user/resend-otp',
+    '/session/resend-code',
     [middlewareBodyExists('email')],
     user.routeSendOTP
   );
@@ -129,12 +129,19 @@ function run() {
   // OTP code verification also through a POST request. If successful, it will
   // send back the needed authentication tokens.
   app.post(
-    '/user/verify',
+    '/session/verify',
     [
       middlewareBodyExists('email'),
       middlewareBodyExists('code')
     ],
     user.routeVerifyOTP
+  );
+
+  // When logged in, you can refresh your own tokens whenever needed.
+  app.post(
+    '/session/refresh',
+    [middlewareVerifyJWT(REFRESH_JWT)],
+    user.routeRefreshTokens
   );
 
   /*
@@ -143,13 +150,6 @@ function run() {
    * These routes are protected by JWT verification (the middlewareVerifyJWT function)
    * since they correspond to a particular user.
    */
-
-  // When logged in, you can refresh your own tokens whenever needed.
-  app.post(
-    '/user/token-refresh',
-    [middlewareVerifyJWT(REFRESH_JWT)],
-    user.routeRefreshTokens
-  );
 
   // Get your own data by requesting it with a GET request.
   app.get(

--- a/src/backend/test/test_api.js
+++ b/src/backend/test/test_api.js
@@ -320,13 +320,13 @@ describe('Test API', () => {
         });
 
         /*
-         * TEST /user/token-refresh ROUTE 
+         * TEST /session/refresh ROUTE 
          */ 
 
-        describe('POST /user/token-refresh', () => {
+        describe('POST /session/refresh', () => {
             it('returns new tokens', async () => {
                 const res = await req
-                    .post('/user/token-refresh')
+                    .post('/session/refresh')
                     .set('Authorization', `Bearer ${refresh_token}`)
                     .set('Content-Type', 'application/json');
 
@@ -346,7 +346,7 @@ describe('Test API', () => {
             // not the auth token.
             it('gives 401 when the token is not included', async () => {
                 const res = await req
-                    .post('/user/token-refresh')
+                    .post('/session/refresh')
                     .set('Authorization', `Bearer not_a_real_token_lol`)
                     .set('Content-Type', 'application/json');
                 assert.strictEqual(res.statusCode, 403, res.text);
@@ -354,7 +354,7 @@ describe('Test API', () => {
 
             it('gives 403 when the token is not good', async () => {
                 const res = await req
-                    .post('/user/token-refresh')
+                    .post('/session/refresh')
                     .set('Authorization', `Bearer not_a_real_token_lol`)
                     .set('Content-Type', 'application/json');
                 assert.strictEqual(res.statusCode, 403, res.text);
@@ -363,7 +363,7 @@ describe('Test API', () => {
             it('gives 404 when the user does not exist', async () => {
                 const fakeTokens = util.generateUserTokens('fake@example.com');
                 const res = await req
-                    .post('/user/token-refresh')
+                    .post('/session/refresh')
                     .set('Authorization', `Bearer ${fakeTokens.refresh}`)
                     .set('Content-Type', 'application/json');
                 assert.strictEqual(res.statusCode, 404, res.text);

--- a/test procedures/api.md
+++ b/test procedures/api.md
@@ -51,7 +51,7 @@ so make sure you're okay with doing this or take a backup first!
 
 ## Sign up for a new account
 
-1. Make a request to the `/user/signup` API endpoint, specifying the new account you want to create.
+1. Make a request to the `/session/signup` API endpoint, specifying the new account you want to create.
 
    For instance, this is almond's request since they do testing a lot and wanna copy+paste.
 
@@ -60,7 +60,7 @@ so make sure you're okay with doing this or take a backup first!
       -H 'Content-Type: application/json' \
       --request POST \
       --data '{"email":"heilalmond@grinnell.edu", "username":"almond"}' \
-      http://localhost:8080/user/signup | jq
+      http://localhost:8080/session/signup | jq
    ```
 
 2. Confirm the response is positive. It should look like this.
@@ -76,7 +76,7 @@ so make sure you're okay with doing this or take a backup first!
 1. Check your Grinnell outlook for an email from getgrinnected@gmail.com,
    and copy the code inside.
 
-2. Use the code to send another POST request, this time to the `/user/verify`
+2. Use the code to send another POST request, this time to the `/session/verify`
    endpoint.
 
    ```bash
@@ -84,7 +84,7 @@ so make sure you're okay with doing this or take a backup first!
       -H 'Content-Type: application/json' \
       --request POST \
       --data '{"email":"heilalmond@grinnell.edu", "code":"123456"}' \
-      http://localhost:8080/user/verify | jq
+      http://localhost:8080/session/verify | jq
    ```
 
 3. Make sure your response looks good. Here's mine, only I changed the tokens to be the example one from <https://jwt.io> so I'm not leaking anything.
@@ -109,7 +109,7 @@ so make sure you're okay with doing this or take a backup first!
       -H 'Content-Type: application/json' \
       --request POST \
       --data '{"email":"heilalmond@grinnell.edu"}' \
-      http://localhost:8080/user/login | jq
+      http://localhost:8080/session/login | jq
    ```
 
 2. It should respond with this.


### PR DESCRIPTION
This PR changes the routes that deal with the user session from being `/user/...` routes to `/session/...` routes instead.

After this change is deployed, frontends will need to change the URLs they access. It will be simple find-and-replace.

- `/user/login` -> `/session/login`
- `/user/signup` -> `/session/signup`
- `/user/resend-otp` -> `/session/resend-code`
- `/user/verify` -> `/session/verify`
- `/user/token-refresh` -> `/session/refresh`

I will also post an announcement when that does happen.