### PR TITLE
Visual changes

### DIFF
--- a/src/ios/GetGrinnected/GetGrinnected.xcodeproj/project.pbxproj
+++ b/src/ios/GetGrinnected/GetGrinnected.xcodeproj/project.pbxproj
@@ -35,7 +35,7 @@
 		4CA0C5772DA5D16200059803 /* Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA0C5762DA5D15300059803 /* Header.swift */; };
 		CA0EB8C52DB00AAC005898BA /* DayCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0EB8C42DB00A9F005898BA /* DayCard.swift */; };
 		CA0EB8C92DB2AA63005898BA /* WeekView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA0EB8C82DB2AA61005898BA /* WeekView.swift */; };
-		CA3109F82DC28D7900875D8C /* SearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA3109F72DC28D7900875D8C /* SearchBar.swift */; };
+		CA310A0A2DC3C13B00875D8C /* SearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA310A092DC3C13800875D8C /* SearchBar.swift */; };
 		CA3B0A462DBB583500A270FA /* DateFormatter+apiDateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA3B0A452DBB582A00A270FA /* DateFormatter+apiDateFormatter.swift */; };
 		CA6DF8412DA6116500EFE10A /* Logo.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA6DF8402DA6116300EFE10A /* Logo.swift */; };
 		CAA8FE8A2DB92AF3005C6BBE /* ParentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA8FE882DB92AF3005C6BBE /* ParentView.swift */; };
@@ -138,7 +138,7 @@
 		4CD5D1B62D9A119D001E91BD /* GetGrinnectedTestsCI.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GetGrinnectedTestsCI.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		CA0EB8C42DB00A9F005898BA /* DayCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayCard.swift; sourceTree = "<group>"; };
 		CA0EB8C82DB2AA61005898BA /* WeekView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeekView.swift; sourceTree = "<group>"; };
-		CA3109F72DC28D7900875D8C /* SearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBar.swift; sourceTree = "<group>"; };
+		CA310A092DC3C13800875D8C /* SearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBar.swift; sourceTree = "<group>"; };
 		CA3B0A452DBB582A00A270FA /* DateFormatter+apiDateFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter+apiDateFormatter.swift"; sourceTree = "<group>"; };
 		CA6DF8402DA6116300EFE10A /* Logo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logo.swift; sourceTree = "<group>"; };
 		CAA8FE882DB92AF3005C6BBE /* ParentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentView.swift; sourceTree = "<group>"; };
@@ -298,7 +298,7 @@
 		CACCD44A2DA31696001D31C0 /* Components */ = {
 			isa = PBXGroup;
 			children = (
-				CA3109F72DC28D7900875D8C /* SearchBar.swift */,
+				CA310A092DC3C13800875D8C /* SearchBar.swift */,
 				CA0EB8C82DB2AA61005898BA /* WeekView.swift */,
 				CA0EB8C42DB00A9F005898BA /* DayCard.swift */,
 				CA6DF8402DA6116300EFE10A /* Logo.swift */,
@@ -505,6 +505,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CA310A0A2DC3C13B00875D8C /* SearchBar.swift in Sources */,
 				CA3B0A462DBB583500A270FA /* DateFormatter+apiDateFormatter.swift in Sources */,
 				CA0EB8C52DB00AAC005898BA /* DayCard.swift in Sources */,
 				CA0EB8C92DB2AA63005898BA /* WeekView.swift in Sources */,

--- a/src/ios/GetGrinnected/GetGrinnected/Assets.xcassets/Colors/ColorWhite.colorset/Contents.json
+++ b/src/ios/GetGrinnected/GetGrinnected/Assets.xcassets/Colors/ColorWhite.colorset/Contents.json
@@ -2,12 +2,12 @@
   "colors" : [
     {
       "color" : {
-        "color-space" : "srgb",
+        "color-space" : "extended-srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.333",
-          "green" : "0.176",
-          "red" : "1.000"
+          "blue" : "0.996",
+          "green" : "0.998",
+          "red" : "1.005"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "display-p3",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.303",
-          "green" : "0.160",
-          "red" : "0.893"
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
         }
       },
       "idiom" : "universal"

--- a/src/ios/GetGrinnected/GetGrinnected/Components/Header.swift
+++ b/src/ios/GetGrinnected/GetGrinnected/Components/Header.swift
@@ -36,6 +36,7 @@ struct Header: View{
                 Text(title)
                     .font(.title)
                     .bold()
+                    .foregroundStyle(.colorWhite)
             }//hstack for content and buttons
             .padding(.bottom)
             .frame(maxWidth: .infinity)

--- a/src/ios/GetGrinnected/GetGrinnected/Components/SearchBar.swift
+++ b/src/ios/GetGrinnected/GetGrinnected/Components/SearchBar.swift
@@ -16,9 +16,10 @@ struct SearchBar: View {
             HStack(spacing: 8){
                 Image(systemName: "magnifyingglass")
                     .foregroundColor(.white)
-                TextField("Search", text: Binding(
+                TextField ("Search", text: Binding(
                     get: { inputText },
-                    set: { inputText = $0 }))
+                    set: { inputText = $0 })
+                )
                 .foregroundColor(.white)
                 .tint(.white)
             }
@@ -35,6 +36,7 @@ struct SearchBar: View {
             Logo(size: 35)
         }//HStack for searching
         .padding(.top, safeAreaTop + 10)
+        .padding(.leading)
         .background{
             Rectangle()
                 .fill(.colorBlue)

--- a/src/ios/GetGrinnected/GetGrinnected/Components/WeekView.swift
+++ b/src/ios/GetGrinnected/GetGrinnected/Components/WeekView.swift
@@ -163,7 +163,7 @@ struct WeekView: View {
                             RoundedRectangle(cornerRadius: 8)
                                 .stroke(Color.appBorder, lineWidth: 1)
                         }
-                    )//bacgkground
+                    )//background
                     .foregroundColor(.appTextPrimary)
                     .cornerRadius(8)
                 }

--- a/src/ios/GetGrinnected/GetGrinnected/CoreViews/FavoritesView.swift
+++ b/src/ios/GetGrinnected/GetGrinnected/CoreViews/FavoritesView.swift
@@ -22,7 +22,7 @@ struct FavoritesView: View {
     @State private var refreshTimer: Timer? //a timer to count when we refresh
     
     //Sorting and Filtering parameters
-    @State private var sortOrder = SortOrder.eventTime
+    @State private var sortOrder = SortOrder.time
     @State private var filterType = FilterType.name
     @State private var filter = ""
     @State private var selectedEvent: Int = -1

--- a/src/ios/GetGrinnected/GetGrinnected/CoreViews/HomeView.swift
+++ b/src/ios/GetGrinnected/GetGrinnected/CoreViews/HomeView.swift
@@ -17,7 +17,7 @@ struct HomeView: View {
     
     
     //Sorting and Filtering parameters
-    @State private var sortOrder = SortOrder.eventTime
+    @State private var sortOrder = SortOrder.time
     @State private var filterType = FilterType.name
     @State private var filter = ""
     
@@ -36,20 +36,20 @@ struct HomeView: View {
                         VStack(spacing: 16) {
                             WeekView(selectedDate: $viewModel.viewedDate)
                                 .padding(.bottom, 4)
-                                .padding(.top, 120)
+                                .padding(.top, 140)
                             
                             //event list view for all the events (may have to pass in some arguments according to the day
                             EventList(parentView: viewModel, selectedEvent: -1, sortOrder: sortOrder, filterType: filterType, filter: searchText, filterToday: searchText.isEmpty)
                         }
                         .padding(.top)//padding on top
                     }
-                    .searchable(text: $searchText, prompt: "Search...")
                    .refreshable {
                        //force refresh through the button!
                        viewModel.forceRefresh() //only changes last change to nil
                    }
                 }//scroll view
                 .edgesIgnoringSafeArea(.top)
+                .searchable(text: $searchText, prompt: "Search...")
             }
             .navigationTitle("Calendar")
             .headerProminence(.increased)

--- a/src/ios/GetGrinnected/GetGrinnected/CoreViews/SearchView.swift
+++ b/src/ios/GetGrinnected/GetGrinnected/CoreViews/SearchView.swift
@@ -24,7 +24,7 @@ struct SearchView: View {
     
     
     //Sorting and Filtering parameters
-    @State private var sortOrder = SortOrder.eventTime
+    @State private var sortOrder = SortOrder.time
     @State private var filterType = FilterType.name
     @State private var filter = ""
     

--- a/src/ios/GetGrinnected/GetGrinnected/CoreViews/SettingsView.swift
+++ b/src/ios/GetGrinnected/GetGrinnected/CoreViews/SettingsView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 struct SettingsView: View {
     // store standard font size of 20 in app storage
-    @AppStorage("FontSize") private var fontSize: Double = 20.0
+    @AppStorage("FontSize") private var fontSize: Double = 15.0
     
     // access the core data to see the color scheme the device is set to
     @Environment(\.colorScheme) private var userColorScheme
@@ -62,26 +62,58 @@ struct SettingsView: View {
                         // change username field
                         InputView(text: $username, title: "Change Username", placeholder: "Username")
                             .padding()
+                            .background( //background color as app container
+                                ZStack {
+                                    Color.appContainer
+                                        .opacity(0.75)
+                                    RoundedRectangle(cornerRadius: 8)
+                                        .stroke(Color.appBorder, lineWidth: 1)
+                                }
+                            )//background
+                            .cornerRadius(8)
                         
                         // switch for light/dark mode
                         Toggle(lightModeOn ? "Light Mode" : "Dark Mode", systemImage: lightModeOn ? "lightswitch.on" : "lightswitch.off", isOn: $lightModeOn)
                             .padding()
+                            .background( //background color as app container
+                                ZStack {
+                                    Color.appContainer
+                                        .opacity(0.75)
+                                    RoundedRectangle(cornerRadius: 8)
+                                        .stroke(Color.appBorder, lineWidth: 1)
+                                }
+                            )//background
+                            .cornerRadius(8)
                         
-                        Text("Font Size")
-                        
-                        // slider for text size
-                        Slider(
-                            value: $fontSize,
-                            in: 20...45,
-                            // has 5 discrete steps instead of a continous slider
-                            step: 5
-                        ) {} minimumValueLabel: {
-                            Text("A")
-                                .font(.system(size: 20))
-                        } maximumValueLabel: {
-                            Text("A")
-                                .font(.system(size: 45))
+                        VStack{
+                            Text("Font Size")
+                                .padding(.top)
+                            
+                            // slider for text size
+                            Slider(
+                                value: $fontSize,
+                                in: 10...45,
+                                // has 5 discrete steps instead of a continous slider
+                                step: 5
+                            ) {} minimumValueLabel: {
+                                Text("Aa")
+                                    .font(.system(size: 10))
+                            } maximumValueLabel: {
+                                Text("Aa")
+                                    .font(.system(size: 45))
+                            }
+                            .padding()
+                            
                         }
+                        .background( //background color as app container
+                            ZStack {
+                                Color.appContainer
+                                    .opacity(0.75)
+                                RoundedRectangle(cornerRadius: 8)
+                                    .stroke(Color.appBorder, lineWidth: 1)
+                            }
+                        )//background
+                        .cornerRadius(8)
                     } //VStack
                     .padding()
                     

--- a/src/ios/GetGrinnected/GetGrinnected/Database/EventList.swift
+++ b/src/ios/GetGrinnected/GetGrinnected/Database/EventList.swift
@@ -16,7 +16,7 @@ import SwiftUI
  Searching, filtering and forcerefreshing is all in this file.
  */
 enum SortOrder: String, Identifiable, CaseIterable {
-    case eventName, eventTime
+    case name, time
     var id: Self { self}
 }
 
@@ -69,9 +69,9 @@ struct EventList: View {
         //apply sort order, default if no title or organization provided
         let sortDescriptors: [SortDescriptor<EventModel>] =
         switch sortOrder {
-        case .eventName:
+        case .name:
             [SortDescriptor(\EventModel.name)]
-        case .eventTime:
+        case .time:
             [SortDescriptor(\EventModel.startTime)]
         }
         


### PR DESCRIPTION
* sortorder name changed from eventTime to time and eventName to name (so sort function displays "name" instead of "eventName" etc.)
* changed default font size to 15 (back to normal size of the search boxes, etc.
* added boxs to all settings options
* adding padding on top of homeview so that the search bar and home view don't overlap
* spellcheck on some comments (weekview)
* adding some padding to search bar, so visually isn't on left-most side of screen
* added explicit call to white color to header text, so settings page no longer looks blue (as it was for some weird reason)
* changed white color to actual white
* removed then added back search bar, as search bar was for some reason not being detected by project