### PR TITLE
Implement, test, and document account deletion

### DIFF
--- a/docs/api-v1.yaml
+++ b/docs/api-v1.yaml
@@ -10,7 +10,7 @@ tags:
   - name: session
     description: Session login and authorization.
   - name: user
-    description: Get and modify logged-in user settings.
+    description: Get and modify logged-in user data.
 paths:
   /session/login:
     post:
@@ -492,6 +492,31 @@ paths:
           $ref: '#/components/responses/InvalidToken'
         '404':
           $ref: '#/components/responses/NoSuchUser'
+  /user:
+    delete:
+      tags:
+        - user
+      summary: Delete user account.
+      description: Delete the account of the currently logged-in user.
+      security:
+        - auth_token: []
+      responses:
+        '200':
+          description: Account deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Account successfully deleted."
+        '404':
+          description: Unknown database error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /events:
     get:
       tags:
@@ -784,7 +809,7 @@ components:
           example: Unknown error
         message:
           type: string
-          example: An unknown error has occured.
+          example: An unknown error has occurred.
     ErrorDateOrder:
       allOf:
         - $ref: '#/components/schemas/Error'

--- a/src/backend/api/api.cjs
+++ b/src/backend/api/api.cjs
@@ -202,6 +202,13 @@ function run() {
     ],
     user.routePutUsername
   );
+
+  // Delete account by sending a request while logged in
+  app.delete(
+    '/user',
+    [middlewareVerifyJWT(ACCESS_JWT)],
+    user.routeDeleteAccount
+  );
 }
 
 /**

--- a/src/backend/api/routes/user.cjs
+++ b/src/backend/api/routes/user.cjs
@@ -302,8 +302,37 @@ async function routeRefreshTokens(req, res, _next) {
   });
 }
 
+/**
+ * Delete the account of the currently logged-in user.
+ * 
+ * @param {*} req 
+ * @param {*} res 
+ * @param {*} _next 
+ */
+async function routeDeleteAccount(req, res, _next) {
+  // Get the email to delete, we know it is included thanks to the middleware.
+  const email = req.email;
+
+  // Ask the database to delete that account
+  try {
+    await db.deleteAccount(email);
+
+    // Return a successful delete
+    res.json({
+      'message': 'Account successfully deleted.'
+    });
+  } catch (error) {
+    // If an error happens, respond saying there was an error instead
+    res.status(404).json({
+      'error': 'Unknown error',
+      'message': error.toString()
+    });
+  }
+}
+
 if (require.main !== module) {
   module.exports = {
+    routeDeleteAccount,
     routeGetFavorited,
     routeGetNotified,
     routeGetUserData,

--- a/src/backend/db_connect.js
+++ b/src/backend/db_connect.js
@@ -310,6 +310,17 @@ async function modifyAccountField(email, field, newValue) {
     return result;
 }
 
+async function deleteAccount(email) {
+    const account = await getAccountByEmail(email);
+    if (!account) {
+        throw new Error('No account to delete');
+    }
+
+    const sql = `DELETE FROM accounts WHERE email = ?`
+    const result = await pool.query(sql, email);
+    return result;
+}
+
 if (require.main === module) {
     // File is being used as a script. Run it.
     insertEventsFromScrape();
@@ -319,6 +330,7 @@ if (require.main === module) {
     module.exports = {
         end,
         createAccount,
+        deleteAccount,
         dropExpiredEvents,
         getAccount,
         getAccountByEmail,


### PR DESCRIPTION
This PR adds a route to delete your account by sending a DELETE request to /user.

It also updates the docs for the API to mention that route, and adds tests since it's possible to automatically test the route.