### PR TITLE
Tweak PUT-ing arrays to ignore invalid items.

### DIFF
--- a/docs/api-v1.yaml
+++ b/docs/api-v1.yaml
@@ -306,7 +306,7 @@ paths:
       security:
         - auth_token: []
       requestBody:
-        description: Array of new favorited event IDs.
+        description: Array of new favorited event IDs. Any nonexistent IDs will be ignored.
         content:
           application/json:
             schema:
@@ -319,7 +319,7 @@ paths:
                     type: integer
       responses:
         '200':
-          description: Successful update.
+          description: Successful update. Any nonexistent IDs will be ignored.
           content:
             application/json:
               schema:
@@ -328,6 +328,11 @@ paths:
                   message:
                     type: string
                     example: Successfully updated favorited_events.
+                  new_value:
+                    type: array
+                    example: [77]
+                    items:
+                      type: integer
         '400':
           description: Bad request.
           content:
@@ -377,7 +382,7 @@ paths:
       tags:
         - user
       summary: Change notified events list.
-      description: Overwrite the array of notified events with a new array.
+      description: Overwrite the array of notified events with a new array. Any nonexistent IDs will be ignored.
       security:
         - auth_token: []
       requestBody:
@@ -393,8 +398,8 @@ paths:
                   items:
                     type: integer
       responses:
-        '202':
-          description: Successful update.
+        '200':
+          description: Successful update. Any nonexistent IDs will be ignored.
           content:
             application/json:
               schema:
@@ -403,6 +408,11 @@ paths:
                   message:
                     type: string
                     example: Successfully updated notified events.
+                  new_value:
+                    type: array
+                    example: [2, 5]
+                    items:
+                      type: integer
         '400':
           description: Bad request.
           content:

--- a/src/backend/api/routes/user.cjs
+++ b/src/backend/api/routes/user.cjs
@@ -187,7 +187,7 @@ async function routeGetFavorited(req, res, _next) {
 async function routePutFavorited(req, res, next) {
   // Set the favorited_events array of that user, and let that function do the response.
   // This assumes the body has `favorited_events`, and the middleware makes sure that is true
-  await util.userDataSetArray('favorited_events', req, res, next);
+  await util.setUserEventArray('favorited_events', req, res, next);
 }
 
 /**
@@ -219,7 +219,7 @@ async function routeGetNotified(req, res, _next) {
 async function routePutNotified(req, res, next) {
   // Set the notified_events array of that user, and let that function do the response.
   // This requires the body contain `notified_events`, which we get thanks to the middleware
-  await util.userDataSetArray('notified_events', req, res, next);
+  await util.setUserEventArray('notified_events', req, res, next);
 }
 
 /**

--- a/src/backend/api/utils.cjs
+++ b/src/backend/api/utils.cjs
@@ -457,11 +457,10 @@ async function setUserEventArray(array_name, req, res, _next) {
 
     // Update that user's favorited events in the database. Turn the array into a
     // string so it will be handled properly by the DB query.
-    const stringified = JSON.stringify(existingIDs)
-    await database.modifyAccountField(email, array_name, JSON.stringify(stringified));
+    await database.modifyAccountField(email, array_name, JSON.stringify(existingIDs));
     res.json({
         'message': `Successfully updated ${array_name}.`,
-        'new_value': stringified  // send back what we did insert, because it may not match what they sent
+        'new_value': existingIDs  // send back what we did insert, because it may not match what they sent
     });
 }
 

--- a/src/backend/api/utils.cjs
+++ b/src/backend/api/utils.cjs
@@ -416,69 +416,52 @@ async function asyncFilter(array, predicate) {
  * - `object` is an array
  * - all elements of `object` correspond to a valid event ID
  */
-async function eventsExist(object) {
+async function filterExistingEvents(object) {
     // Make sure the object is actually an array.
+    // If it is not, return an empty array to represent that.
     const isArray = Array.isArray(object);
     if (!isArray) {
-        return {
-            'result': false,
-            'message': 'Object is not an array.'
-        };
+        return [];
     }
     const array = object;
 
-    // Filter the array by which items do NOT exist.
-    const badIDs = await asyncFilter(array, async (item) => {
+    // Filter the array by which items exist (are not undefined)
+    const goodIDs = await asyncFilter(array, async (item) => {
         const event = await database.getEventByID(item);
-        return event === undefined;
+        return event !== undefined;
     });
 
-    // If there are any items that do not match with an event, return that.
-    if (badIDs.length !== 0) {
-        return {
-            'result': false,
-            'message': `Items ${JSON.stringify(badIDs)} did not correspond to actual event IDs.`
-        };
-    }
-
-    // Otherwise we're good, and we can return true with no message.
-    return {
-        'result': true,
-        'message': 'Success'
-    };
+    // Return that array of IDs.
+    return goodIDs;
 }
 
 /**
- * Handle a request to set an array in user data for a single user, with a parameter
- * that lets you set which array gets modified.
+ * Handle a request to set a user data array containing event IDs.
  * 
  * @param {*} array_name  Which array name to set. Should match up with the account table.
- * @param {*} req  Express request.
- * @param {*} res  Express response.
+ * @param {*} req  Express request. Body must contain `array_name` object, but this
+ * function makes sure it is an array and behaves appropriately.
+ * @param {*} res  Express response. Will always be sent a success, but the array that goes back 
  * @param {*} _next  Next function to call from express, unused.
  */
-async function userDataSetArray(array_name, req, res, _next) {
+async function setUserEventArray(array_name, req, res, _next) {
     // Get the email from the request, assuming it was set by the middleware.
     const email = req.email;
 
     // The new array will be in the request body under the proper array name.
     const newArray = req.body[array_name];
 
-    // Make sure the array is all integers, and that all elements are real events
-    const exist = await eventsExist(newArray);
-    if (!exist.result) {
-        res.status(400).json({
-            'error': 'Invalid request',
-            'message': exist.message
-        });
-        return;
-    }
+    // Get an array of which items are IDs that exist.
+    // If it is invalid for any reason, we'll get an empty array.
+    const existingIDs = await filterExistingEvents(newArray);
 
     // Update that user's favorited events in the database. Turn the array into a
     // string so it will be handled properly by the DB query.
-    await database.modifyAccountField(email, array_name, JSON.stringify(newArray));
+    const stringified = JSON.stringify(existingIDs)
+    await database.modifyAccountField(email, array_name, JSON.stringify(stringified));
     res.json({
-        'message': `Successfully updated ${array_name}`
+        'message': `Successfully updated ${array_name}.`,
+        'new_value': stringified  // send back what we did insert, because it may not match what they sent
     });
 }
 
@@ -492,7 +475,7 @@ if (require.main !== module) {
         sendOTP,
         parseParamDate,
         parseQueryTags,
-        eventsExist,
-        userDataSetArray,
+        filterExistingEvents,
+        setUserEventArray,
     };
 }

--- a/src/backend/test/test_api.js
+++ b/src/backend/test/test_api.js
@@ -143,7 +143,7 @@ describe('Test API', () => {
     /*
      * CHECK ALL AUTHENTICATED API CALLS
      */
-    
+
     var refresh_token;
     var access_token;
     describe('Authenticated', () => {
@@ -331,7 +331,7 @@ describe('Test API', () => {
 
         /*
          * TEST /session/refresh ROUTE 
-         */ 
+         */
 
         describe('POST /session/refresh', () => {
             it('returns new tokens', async () => {
@@ -403,58 +403,74 @@ describe('Test API', () => {
             'favorited',
             'notified'
         ]
-        for (const eventType of arrayEventTypes) {
-            describe(`GET + PUT /user/events/${eventType}`, () => {
-                it('modifies and gets valid events', async () => {
-                    const newItems = [1, 2];
+        // for (const eventType of arrayEventTypes) {
+        //     describe(`GET + PUT /user/events/${eventType}`, () => {
+        //         it('modifies and gets valid events', async () => {
+        //             const newItems = [1, 2];
 
-                    // Create the body, key depends on current eventType
-                    var body = {};
-                    body[`${eventType}_events`] = newItems
+        //             // Create the body, key depends on current eventType
+        //             var body = {};
+        //             body[`${eventType}_events`] = newItems
 
-                    // Make sure it adds the items
-                    const putRes = await req
-                        .put(`/user/events/${eventType}`)
-                        .set('Authorization', `Bearer ${access_token}`)
-                        .set('Content-Type', 'application/json')
-                        .send(body);
-                    assert.strictEqual(putRes.statusCode, 200, putRes.text);
+        //             // Make sure it adds the items
+        //             const putRes = await req
+        //                 .put(`/user/events/${eventType}`)
+        //                 .set('Authorization', `Bearer ${access_token}`)
+        //                 .set('Content-Type', 'application/json')
+        //                 .send(body);
+        //             assert.strictEqual(putRes.statusCode, 200, putRes.text);
 
-                    const getRes = await req
-                        .get(`/user/events/${eventType}`)
-                        .set('Authorization', `Bearer ${access_token}`)
-                        .set('Content-Type', 'application/json');
-                    assert.strictEqual(getRes.statusCode, 200, getRes.text);
-                    assert.strictEqual(getRes.text, `{"${eventType}_events":[1,2]}`);
-                });
+        //             const getRes = await req
+        //                 .get(`/user/events/${eventType}`)
+        //                 .set('Authorization', `Bearer ${access_token}`)
+        //                 .set('Content-Type', 'application/json');
+        //             assert.strictEqual(getRes.statusCode, 200, getRes.text);
+        //             assert.strictEqual(getRes.text, `{"${eventType}_events":[1,2]}`);
+        //         });
 
-                describe('accepts valid inputs and rejects invalid ones', () => {
-                    const inputs = [
-                        { 'input': [], 'status': 200 },
-                        { 'input': [1], 'status': 200 },
-                        { 'input': [5], 'status': 400 },
-                        { 'input': 'a literal string', 'status': 400 },
-                        { 'input': 1, 'status': 400 },
-                    ];
+        //         it('accepts valid inputs and rejects invalid ones', t => {
+        //             const testInputs = [
+        //                 // these should match the input because they are valid
+        //                 { 'input': [], 'expected': [] },
+        //                 { 'input': [1], 'expected': [1] },
+        //                 { 'input': [1, 2], 'expected': [1, 2] },
+        //                 // this should filter out the invalid but keep the valid
+        //                 { 'input': [1, 5], 'expected': [1] },
+        //                 // these should reject all the invalid
+        //                 { 'input': [5], 'expected': [] },
+        //                 { 'input': 'a literal string', 'expected': [] },
+        //                 { 'input': 1, 'expected': [] },
+        //             ];
 
-                    for (item of inputs) {
-                        it(`gives ${item.status} on input ${JSON.stringify(item.input)}`, async () => {
-                            // Construct body with differing event type
-                            var body = {};
-                            body[`${eventType}_events`] = item.input;
+        //             // NOTE: for reasons I still don't understand, naming this
+        //             // `item` causes it to get overwritten by the item in the
+        //             // username tests. concerning but idk how to fix it.
+        //             const cases = testInputs.map((testInput) => {
+        //                 t.it(`sets to ${JSON.stringify(testInput.expected)} on input ${JSON.stringify(testInput.input)}`, async () => {
+        //                     // Construct body with differing event type
+        //                     var body = {};
+        //                     body[`${eventType}_events`] = testInput.input;
 
-                            const res = await req
-                                .put(`/user/events/${eventType}`)
-                                .set('Authorization', `Bearer ${access_token}`)
-                                .set('Content-Type', 'application/json')
-                                .send(body);
+        //                     const res = await req
+        //                         .put(`/user/events/${eventType}`)
+        //                         .set('Authorization', `Bearer ${access_token}`)
+        //                         .set('Content-Type', 'application/json')
+        //                         .send(body);
 
-                            assert.strictEqual(res.statusCode, item.status, res.text);
-                        });
-                    }
-                });
-            });
-        }
+        //                     // all requests should give code 200
+        //                     assert.strictEqual(res.statusCode, 200, res.text);
+
+        //                     // the response for new_value should match the expected
+        //                     const resObject = JSON.parse(res.text);
+        //                     console.log(`resObject.new_value is ${JSON.stringify(resObject.new_value)}`)
+        //                     console.log(`expected new_value is  ${JSON.stringify(testInput.expected)}`);
+        //                 });
+        //             });
+
+        //             // TODO: THIS DOES NOT WORK AND IT NEEDS TO. IT IS UNACCEPTABLE FOR IT TO NOT WORK.
+        //             await Promise.allSettled(cases);
+        //         });
+        //     });
 
         /*
          * TEST /user/username ROUTE
@@ -484,7 +500,7 @@ describe('Test API', () => {
                 assert.strictEqual(getRes.text, `{"username":"${newName}"}`);
             });
 
-            describe('accepts valid usernames and rejects invalid ones', () => {
+            it('accepts valid usernames and rejects invalid ones', { concurrency: true }, async t => {
                 const usernames = [
                     { 'username': 'a', 'status': 200 },
                     { 'username': 'abc123', 'status': 200 },
@@ -500,19 +516,23 @@ describe('Test API', () => {
                     { 'username': 'twenty_characters_max', 'status': 400 },
                     { 'username': 'inv@l!d char$', 'status': 400 },
                     { 'username': '1997', 'status': 400 },
+                    { 'username': '', 'status': 400 }
                 ];
 
-                for (item of usernames) {
-                    it(`gives code ${item.status} for username ${item.username}`, async () => {
-                        const res = await req
+                // Map tests using the test context `t` onto the username array
+                const cases = usernames.map(({ username, status }) => {
+                    t.test(`username "${username}" gets code ${status}`, () => {
+                        req
                             .put('/user/username')
                             .set('Authorization', `Bearer ${access_token}`)
                             .set('Content-Type', 'application/json')
-                            .send({ 'username': item.username });
-
-                        assert.strictEqual(res.status, item.status, res.text);
+                            .send({ 'username': username })
+                            .expect(status);
                     });
-                }
+                });
+
+                // Await all of the tests to be evaluated
+                await Promise.allSettled(cases);
             });
         });
     });

--- a/src/backend/test/test_api.js
+++ b/src/backend/test/test_api.js
@@ -168,117 +168,111 @@ describe('Test API', () => {
          */
 
         describe('Error handling', () => {
-            // These arrays are used to parameterize which routes we test.
+            // These tests check if our routes handle auth errors properly.
             //
             // A route is (in general) a way the API lets us interact with it.
             // The most important thing is the name, becuase it lets us construct
             // the URL we use to access it.
 
-            // For routes that we GET (read) information from, we only need the
-            // names in order to access them
-            const getRouteNames = [
-                '/user/data',
-                '/user/events/favorited',
-                '/user/events/notified',
-                '/user/username',
-            ];
-            // For routes that PUT (write) information, we also need to know what
-            // information we are writing to test them fully. That's why we add
-            // this "body" key within the object.
-            const putRouteData = [
-                { 'name': '/user/events/favorited', 'body': 'favorited_events' },
-                { 'name': '/user/events/notified', 'body': 'notified_events' },
-                { 'name': '/user/username', 'body': 'username' }
-            ];
-
             // Test all routes that PUT data
             describe('PUT routes', () => {
-                for (const item of putRouteData) {
-                    it(`PUT ${item.name} gives 400 when no body is included`, async () => {
-                        // Make the request
-                        const res = await req
-                            // URL ending
-                            .put(item.name)
-                            // Headers
-                            .set('Authorization', `Bearer ${access_token}`)
-                            .set('Content-Type', 'application/json')
+                // For routes that PUT (write) information, we need to know what
+                // information we are writing to test them fully. That's why we add
+                // this "body" key within the object.
+                const putRouteData = [
+                    { 'name': '/user/events/favorited', 'body': 'favorited_events' },
+                    { 'name': '/user/events/notified', 'body': 'notified_events' },
+                    { 'name': '/user/username', 'body': 'username' }
+                ];
 
-                        assert.strictEqual(res.statusCode, 400, res.text);
+                it('give 400 when no body is included', { concurrency: true }, async t => {
+                    const cases = putRouteData.map(async ({ name }) => {
+                        await t.test(name, async () => {
+                            const res = await req
+                                .put(name)
+                                .set('Authorization', `Bearer ${access_token}`)
+                                .set('Content-Type', 'application/json');
+
+                            assert.strictEqual(res.statusCode, 400, res.text);
+                        });
                     });
 
-                    it(`PUT ${item.name} gives 400 when body is included without correct key`, async () => {
-                        // Create the request body, but omit the correct key.
-                        var jsonBody = {};
+                    await Promise.allSettled(cases);
+                });
 
-                        // Make the request
-                        const res = await req
-                            // URL ending
-                            .put(item.name)
-                            // Headers
-                            .set('Authorization', `Bearer ${access_token}`)
-                            .set('Content-Type', 'application/json')
-                            // Body
-                            .send(jsonBody);
+                it('give 400 when body is included with wrong key', { concurrency: true }, async t => {
+                    const cases = putRouteData.map(async ({ name }) => {
+                        await t.test(name, async () => {
+                            const res = await req
+                                .put(name)
+                                .set('Authorization', `Bearer ${access_token}`)
+                                .set('Content-Type', 'application/json')
+                                .send({}); // send an empty body
 
-                        assert.strictEqual(res.statusCode, 400, res.text);
+                            assert.strictEqual(res.statusCode, 400, res.text);
+                        });
                     });
 
-                    it(`PUT ${item.name} gives 401 when token is not provided`, async () => {
-                        // Create the request body to have the required key
-                        var jsonBody = {};
-                        jsonBody[item.body] = 'fake_but_present';
+                    await Promise.allSettled(cases);
+                });
 
-                        // Make the request
-                        const res = await req
-                            // URL ending
-                            .put(item.name)
-                            // Headers
-                            .set('Content-Type', 'application/json')
-                            // Body
-                            .send(jsonBody);
+                it('give 401 when token is not provided', { concurrency: true }, async t => {
+                    const cases = putRouteData.map(async ({ name, body }) => {
+                        var jsonBody = {}
+                        jsonBody[body] = 'fake_but_present';
 
-                        assert.strictEqual(res.statusCode, 401, res.text);
+                        await t.test(name, async () => {
+                            const res = await req
+                                .put(name)
+                                .set('Content-Type', 'application/json')
+                                .send(jsonBody);
+
+                            assert.strictEqual(res.statusCode, 401, res.text);
+                        });
                     });
 
-                    it(`PUT ${item.name} gives 403 when the token is not good`, async () => {
-                        // Create the request body to have the required key
-                        var jsonBody = {};
-                        jsonBody[item.body] = 'fake_but_present';
+                    await Promise.allSettled(cases);
+                });
 
-                        // Make the request
-                        const res = await req
-                            // URL ending
-                            .put(item.name)
-                            // Headers
-                            .set('Authorization', `Bearer invalid_token`)
-                            .set('Content-Type', 'application/json')
-                            // Body
-                            .send(jsonBody);
+                it('give 403 when the token is not good', { concurrency: true }, async t => {
+                    const cases = putRouteData.map(async ({ name, body }) => {
+                        var jsonBody = {}
+                        jsonBody[body] = 'fake_but_present';
 
-                        assert.strictEqual(res.statusCode, 403, res.text);
+                        await t.test(name, async () => {
+                            const res = await req
+                                .put(name)
+                                .set('Content-Type', 'application/json')
+                                .set('Authorization', `Bearer invalid_token`)
+                                .send(jsonBody);
+
+                            assert.strictEqual(res.statusCode, 403, res.text);
+                        });
                     });
 
-                    it(`PUT ${item.name} gives 404 when the user does not exist`, async () => {
-                        // Generate tokens for a user that's not really in the db.
-                        const fakeTokens = util.generateUserTokens('fake@example.com');
+                    await Promise.allSettled(cases);
+                });
 
-                        // Create the request body to have the required key
-                        var jsonBody = {};
-                        jsonBody[item.body] = 'fake_but_present';
+                it('give 404 when the user does not exist', { concurrency: true }, async t => {
+                    const fakeTokens = util.generateUserTokens('fake@example.com');
 
-                        // Make the request
-                        const res = await req
-                            // URL ending
-                            .put(item.name)
-                            // Headers
-                            .set('Authorization', `Bearer ${fakeTokens.access}`)
-                            .set('Content-Type', 'application/json')
-                            // Body
-                            .send(jsonBody);
+                    const cases = putRouteData.map(async ({ name, body }) => {
+                        var jsonBody = {}
+                        jsonBody[body] = 'fake_but_present';
 
-                        assert.strictEqual(res.statusCode, 404, res.text);
+                        await t.test(name, async () => {
+                            const res = await req
+                                .put(name)
+                                .set('Content-Type', 'application/json')
+                                .set('Authorization', `Bearer ${fakeTokens.access}`)
+                                .send(jsonBody);
+
+                            assert.strictEqual(res.statusCode, 404, res.text);
+                        });
                     });
-                }
+
+                    await Promise.allSettled(cases);
+                });
             });
 
             // Test all routes that GET data.
@@ -287,45 +281,58 @@ describe('Test API', () => {
             // check for that error.
             // (also I don't think I can parameterize doing a get vs a put request)
             describe('GET routes', () => {
-                for (const name of getRouteNames) {
-                    it(`GET ${name} gives 401 when token is not provided`, async () => {
-                        // Make the request
-                        const res = await req
-                            // URL ending
-                            .get(name)
-                            // Headers
-                            .set('Content-Type', 'application/json');
+                const getRouteNames = [
+                    '/user/events/favorited',
+                    '/user/username',
+                    '/user/events/notified',
+                    '/user/data'
+                ];
 
-                        assert.strictEqual(res.statusCode, 401, res.text);
+                it('give 401 when token is not provided', { concurrency: true }, async t => {
+                    const cases = getRouteNames.map(async (name) => {
+                        await t.test(name, async () => {
+                            const res = await req
+                                .get(name)
+                                .set('Content-Type', 'application/json');
+
+                            assert.strictEqual(res.statusCode, 401);
+                        });
                     });
 
-                    it(`GET ${name} gives 403 when the token is not good`, async () => {
-                        // Make the request
-                        const res = await req
-                            // URL ending
-                            .get(name)
-                            // Headers
-                            .set('Authorization', `Bearer invalid_token`)
-                            .set('Content-Type', 'application/json');
+                    await Promise.allSettled(cases);
+                });
 
-                        assert.strictEqual(res.statusCode, 403, res.text);
+                it('give 403 when token is not provided', { concurrency: true }, async t => {
+                    const cases = getRouteNames.map(async (name) => {
+                        await t.test(name, async () => {
+                            const res = await req
+                                .get(name)
+                                .set('Content-Type', 'application/json')
+                                .set('Authorization', `Bearer invalid_token`);
+
+                            assert.strictEqual(res.statusCode, 403);
+                        });
                     });
 
-                    it(`GET ${name} gives 404 when the user does not exist`, async () => {
-                        // Generate tokens for a user that's not really in the db.
-                        const fakeTokens = util.generateUserTokens('fake@example.com');
+                    await Promise.allSettled(cases);
+                });
 
-                        // Make the request
-                        const res = await req
-                            // URL ending
-                            .get(name)
-                            // Headers
-                            .set('Authorization', `Bearer ${fakeTokens.access}`)
-                            .set('Content-Type', 'application/json');
+                it('give 404 when user does not exist', { concurrency: true }, async t => {
+                    const fakeTokens = util.generateUserTokens('fake@example.com');
 
-                        assert.strictEqual(res.statusCode, 404, res.text);
+                    const cases = getRouteNames.map(async (name) => {
+                        await t.test(name, async () => {
+                            const res = await req
+                                .get(name)
+                                .set('Content-Type', 'application/json')
+                                .set('Authorization', `Bearer ${fakeTokens.access}`);
+
+                            assert.strictEqual(res.statusCode, 404, res.text);
+                        });
                     });
-                }
+
+                    await Promise.allSettled(cases);
+                });
             });
         });
 
@@ -403,74 +410,87 @@ describe('Test API', () => {
             'favorited',
             'notified'
         ]
-        // for (const eventType of arrayEventTypes) {
-        //     describe(`GET + PUT /user/events/${eventType}`, () => {
-        //         it('modifies and gets valid events', async () => {
-        //             const newItems = [1, 2];
+        describe(`GET + PUT /user/events/ arrays`, () => {
+            it('modifies and gets valid events', async t => {
+                const types = arrayEventTypes.map(async (name) => {
+                    await t.test(`${name}`, async () => {
+                        // Create the body, key depends on current eventType
+                        var body = {};
+                        body[`${name}_events`] = [1, 2];
 
-        //             // Create the body, key depends on current eventType
-        //             var body = {};
-        //             body[`${eventType}_events`] = newItems
+                        // Make sure it adds the items
+                        const putRes = await req
+                            .put(`/user/events/${name}`)
+                            .set('Authorization', `Bearer ${access_token}`)
+                            .set('Content-Type', 'application/json')
+                            .send(body);
+                        assert.strictEqual(putRes.statusCode, 200, putRes.text);
 
-        //             // Make sure it adds the items
-        //             const putRes = await req
-        //                 .put(`/user/events/${eventType}`)
-        //                 .set('Authorization', `Bearer ${access_token}`)
-        //                 .set('Content-Type', 'application/json')
-        //                 .send(body);
-        //             assert.strictEqual(putRes.statusCode, 200, putRes.text);
+                        const getRes = await req
+                            .get(`/user/events/${name}`)
+                            .set('Authorization', `Bearer ${access_token}`)
+                            .set('Content-Type', 'application/json');
+                        assert.strictEqual(getRes.statusCode, 200, getRes.text);
+                        assert.strictEqual(getRes.text, `{"${name}_events":[1,2]}`);
+                    });
+                });
 
-        //             const getRes = await req
-        //                 .get(`/user/events/${eventType}`)
-        //                 .set('Authorization', `Bearer ${access_token}`)
-        //                 .set('Content-Type', 'application/json');
-        //             assert.strictEqual(getRes.statusCode, 200, getRes.text);
-        //             assert.strictEqual(getRes.text, `{"${eventType}_events":[1,2]}`);
-        //         });
+                await Promise.allSettled(types);
+            });
 
-        //         it('accepts valid inputs and rejects invalid ones', t => {
-        //             const testInputs = [
-        //                 // these should match the input because they are valid
-        //                 { 'input': [], 'expected': [] },
-        //                 { 'input': [1], 'expected': [1] },
-        //                 { 'input': [1, 2], 'expected': [1, 2] },
-        //                 // this should filter out the invalid but keep the valid
-        //                 { 'input': [1, 5], 'expected': [1] },
-        //                 // these should reject all the invalid
-        //                 { 'input': [5], 'expected': [] },
-        //                 { 'input': 'a literal string', 'expected': [] },
-        //                 { 'input': 1, 'expected': [] },
-        //             ];
+            it('accepts valid inputs and rejects invalid ones', async t => {
+                const testInputs = [
+                    // these should match the input because they are valid
+                    { 'input': [], 'expected': [] },
+                    { 'input': [1], 'expected': [1] },
+                    { 'input': [1, 2], 'expected': [1, 2] },
+                    // this should filter out the invalid but keep the valid
+                    { 'input': [1, 5], 'expected': [1] },
+                    // these should reject all the invalid
+                    { 'input': [5], 'expected': [] },
+                    { 'input': 'a literal string', 'expected': [] },
+                    { 'input': 1, 'expected': [] },
+                ];
 
-        //             // NOTE: for reasons I still don't understand, naming this
-        //             // `item` causes it to get overwritten by the item in the
-        //             // username tests. concerning but idk how to fix it.
-        //             const cases = testInputs.map((testInput) => {
-        //                 t.it(`sets to ${JSON.stringify(testInput.expected)} on input ${JSON.stringify(testInput.input)}`, async () => {
-        //                     // Construct body with differing event type
-        //                     var body = {};
-        //                     body[`${eventType}_events`] = testInput.input;
+                // this mapping tests over both types of array
+                const types = arrayEventTypes.map(async (name) => {
+                    await t.test(`${name}`, async tInner => {
 
-        //                     const res = await req
-        //                         .put(`/user/events/${eventType}`)
-        //                         .set('Authorization', `Bearer ${access_token}`)
-        //                         .set('Content-Type', 'application/json')
-        //                         .send(body);
+                        // this mapping tests over all the test inputs
+                        const cases = testInputs.map(async ({ input, expected }) => {
+                            await tInner.test(`${JSON.stringify(input)} -> ${JSON.stringify(expected)}`, async () => {
+                                // Construct body with differing event type
+                                var body = {};
+                                body[`${name}_events`] = input;
 
-        //                     // all requests should give code 200
-        //                     assert.strictEqual(res.statusCode, 200, res.text);
+                                const res = await req
+                                    .put(`/user/events/${name}`)
+                                    .set('Authorization', `Bearer ${access_token}`)
+                                    .set('Content-Type', 'application/json')
+                                    .send(body);
 
-        //                     // the response for new_value should match the expected
-        //                     const resObject = JSON.parse(res.text);
-        //                     console.log(`resObject.new_value is ${JSON.stringify(resObject.new_value)}`)
-        //                     console.log(`expected new_value is  ${JSON.stringify(testInput.expected)}`);
-        //                 });
-        //             });
+                                // all requests should give code 200
+                                assert.strictEqual(res.statusCode, 200, res.text);
 
-        //             // TODO: THIS DOES NOT WORK AND IT NEEDS TO. IT IS UNACCEPTABLE FOR IT TO NOT WORK.
-        //             await Promise.allSettled(cases);
-        //         });
-        //     });
+                                // the response for new_value should match the expected
+                                const resObject = JSON.parse(res.text);
+                                assert.strictEqual(
+                                    resObject.new_value,
+                                    JSON.stringify(expected),
+                                    res.text
+                                );
+                            });
+                        });
+
+                        // wait for all cases to evaluate
+                        await Promise.allSettled(cases);
+                    });
+                });
+
+                // and wait for both types to be evaluated
+                await Promise.allSettled(types);
+            });
+        });
 
         /*
          * TEST /user/username ROUTE
@@ -520,14 +540,15 @@ describe('Test API', () => {
                 ];
 
                 // Map tests using the test context `t` onto the username array
-                const cases = usernames.map(({ username, status }) => {
-                    t.test(`username "${username}" gets code ${status}`, () => {
-                        req
+                const cases = usernames.map(async ({ username, status }) => {
+                    await t.test(`"${username}"`, async () => {
+                        const res = await req
                             .put('/user/username')
                             .set('Authorization', `Bearer ${access_token}`)
                             .set('Content-Type', 'application/json')
-                            .send({ 'username': username })
-                            .expect(status);
+                            .send({ 'username': username });
+
+                        assert.strictEqual(res.statusCode, status, res.text);
                     });
                 });
 

--- a/src/backend/test/test_api.js
+++ b/src/backend/test/test_api.js
@@ -431,7 +431,7 @@ describe('Test API', () => {
                             .set('Authorization', `Bearer ${access_token}`)
                             .set('Content-Type', 'application/json');
                         assert.strictEqual(getRes.statusCode, 200, getRes.text);
-                        assert.strictEqual(getRes.text, `{"${name}_events":"[1,2]"}`);
+                        assert.strictEqual(getRes.text, `{"${name}_events":[1,2]}`);
                     });
                 });
 

--- a/src/backend/test/test_api.js
+++ b/src/backend/test/test_api.js
@@ -431,7 +431,7 @@ describe('Test API', () => {
                             .set('Authorization', `Bearer ${access_token}`)
                             .set('Content-Type', 'application/json');
                         assert.strictEqual(getRes.statusCode, 200, getRes.text);
-                        assert.strictEqual(getRes.text, `{"${name}_events":[1,2]}`);
+                        assert.strictEqual(getRes.text, `{"${name}_events":"[1,2]"}`);
                     });
                 });
 

--- a/src/backend/test/test_api.js
+++ b/src/backend/test/test_api.js
@@ -474,11 +474,7 @@ describe('Test API', () => {
 
                                 // the response for new_value should match the expected
                                 const resObject = JSON.parse(res.text);
-                                assert.strictEqual(
-                                    resObject.new_value,
-                                    JSON.stringify(expected),
-                                    res.text
-                                );
+                                assert.ok(arraysEqual(resObject.new_value, expected), res.text);
                             });
                         });
 


### PR DESCRIPTION
In this PR, I tweaked the behavior of PUT requests to /user/events/favorited and /user/events/notified so that they ignore invalid items, and include an array in their response saying which items were actually added.

This also involved some major test rewrites because I had to change the parameterized tests, which led to me finding out they had been broken and totally changing how they work.

I would especially appreciate feedback on the actual code changes (`src/backend/api/utils.cjs` and `src/backend/api/routes/user.cjs`), but if you have comments on the tests or the docs changes don't hesitate to bring it up.