### PR TITLE
Screen Reader Compatibility, Delete User, Readjustments to Font Spacing and Sizing

### DIFF
--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/ApiModel.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/ApiModel.kt
@@ -2,6 +2,7 @@ package com.example.myapplication
 
 import retrofit2.Response
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.POST
@@ -47,4 +48,8 @@ interface ApiModel {
     // Async function to update the remote databases current username for a user
     @PUT("user/username")
     suspend fun updateUsername(@Header("Authorization") token: String, @Body usernameRequest: UpdateUsernameRequest): Response<SimpleMessageResponse>
+
+    // Async function to delete the user account
+    @DELETE("user")
+    suspend fun deleteAccount(@Header("Authorization") token: String): Response<SimpleMessageResponse>
 }

--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/AppRepository.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/AppRepository.kt
@@ -256,7 +256,17 @@ object AppRepository {
         }
     }
 
-
+    /**
+     * Deletes user account
+     * @param context the current context of the app.
+     * @return a boolean value associated with whether deletion was successful or not
+     */
+    suspend fun deleteAccount(context: Context): Boolean {
+        val response = safeApiCall(context) { token ->
+            RetrofitApiClient.apiModel.deleteAccount(token)
+        }
+        return response.isSuccessful
+    }
 }
 
 /**

--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/CheckBox.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/CheckBox.kt
@@ -9,6 +9,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 
 /**
  * A composable function that creates a checkbox and associated text
@@ -28,7 +30,9 @@ fun CheckBox(check: Check) {
         //creates a checkbox
         Checkbox(
             checked = check.checked.value,
-            onCheckedChange = { check.checked.value = it }
+            onCheckedChange = { check.checked.value = it },
+            modifier = Modifier
+                .semantics { contentDescription = "Tag: ${check.label}, ${if (check.checked.value) "selected" else "not selected"}" }
         )
         // checkbox label
         Text (check.label)

--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/EventCard.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/EventCard.kt
@@ -31,6 +31,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
@@ -72,13 +76,15 @@ fun EventCard(event: Event, modifier: Modifier = Modifier) {
     // Sets up composable to be a card for our info
     Card(
         colors = CardDefaults.cardColors(containerColor = colorScheme.secondaryContainer),
-        //elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
         modifier = modifier
             .defaultMinSize(minHeight = 120.dp)
             .padding(horizontal = 8.dp)
-            .clickable
-        {
+            .clickable {
                 expanded.value = !expanded.value
+            }
+            .semantics(mergeDescendants = true) {
+                contentDescription = "Event card for ${event.event_name}, tap to ${if (expanded.value) "collapse" else "expand"}"
+                role = Role.Button
             },
         elevation = CardDefaults.cardElevation(defaultElevation = 8.dp)
     ) {
@@ -129,7 +135,7 @@ fun EventCard(event: Event, modifier: Modifier = Modifier) {
                     // This is our favorite icon
                     Icon(
                         imageVector = if (event.is_favorited) Icons.Filled.Favorite else Icons.Outlined.FavoriteBorder,
-                        contentDescription = "Favorite Icon",
+                        contentDescription = if (event.is_favorited) "Unfavorite event" else "Favorite event",
                         tint = colorScheme.tertiary,
                         modifier = Modifier
                             .size(40.dp)
@@ -143,7 +149,7 @@ fun EventCard(event: Event, modifier: Modifier = Modifier) {
                     // This is our notification icon
                     Icon(
                         imageVector = if (event.is_notification) Icons.Filled.Notifications else Icons.Outlined.Notifications,
-                        contentDescription = "Notification Icon",
+                        contentDescription =  if (event.is_notification) "Turn off notifications" else "Turn on notifications",
                         tint = colorScheme.tertiary,
                         modifier = Modifier
                             .size(40.dp)

--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/FontSizePrefs.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/FontSizePrefs.kt
@@ -10,10 +10,10 @@ enum class FontSizePrefs(
     val fontSizeExtra: Int,
     val label: String
 ) {
-    SMALL("S", -2, "Small"),
-    DEFAULT("M", 0, "Medium"),
-    LARGE("L", 2, "Large"),
-    EXTRA_LARGE("XL", 4, "Extra Large");
+    SMALL("S", 2, "Small"),
+    DEFAULT("M", 4, "Medium"),
+    LARGE("L", 6, "Large"),
+    EXTRA_LARGE("XL", 8, "Extra Large");
 
 companion object {
         fun getFontPrefFromKey(key: String?): FontSizePrefs {

--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/MainActivity.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/com/example/myapplication/MainActivity.kt
@@ -6,11 +6,9 @@ import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.annotation.RequiresApi
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.lifecycle.lifecycleScope
 import com.example.myapplication.ui.theme.MyApplicationTheme
 import kotlinx.coroutines.delay

--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/screens/EmailVerificationScreen.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/screens/EmailVerificationScreen.kt
@@ -136,7 +136,8 @@ fun EmailVerificationScreen(email: String, flag: Boolean, navController: NavCont
                 Text(
                     text = errMsg,
                     color = colorScheme.error,
-                    style = typography.bodySmall
+                    style = typography.bodySmall,
+                    textAlign = TextAlign.Center,
                 )
             }
 

--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/screens/EmailVerificationScreen.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/screens/EmailVerificationScreen.kt
@@ -32,6 +32,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -119,7 +121,7 @@ fun EmailVerificationScreen(email: String, flag: Boolean, navController: NavCont
                 leadingIcon = {
                     Icon(
                         imageVector = Icons.Filled.Lock,
-                        contentDescription = "Verification Icon",
+                        contentDescription = "Verification input field Icon",
                         modifier = Modifier.size(24.dp)
                     )
                 },
@@ -242,7 +244,8 @@ fun EmailVerificationScreen(email: String, flag: Boolean, navController: NavCont
                 Text(
                     "Resend Code",
                     style = typography.labelLarge,
-                    color = colorScheme.primary
+                    color = colorScheme.primary,
+                    modifier = modifier.semantics { contentDescription = "Press to Resend Verification Code" }
                 )
             }
 
@@ -261,7 +264,8 @@ fun EmailVerificationScreen(email: String, flag: Boolean, navController: NavCont
                 Text(
                     "Cancel",
                     style = typography.labelLarge,
-                    color = colorScheme.primary
+                    color = colorScheme.primary,
+                    modifier = modifier.semantics { contentDescription = "Press to navigate back to previous screen" }
                 )
             }
         }

--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/screens/FavoritesScreen.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/screens/FavoritesScreen.kt
@@ -24,6 +24,11 @@ import com.example.myapplication.EventCard
 import com.example.myapplication.toEvent
 import android.content.Context
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 
 /**
  * A composable function that represents the Favorites screen of our app.
@@ -69,7 +74,8 @@ fun FavoritesScreen(modifier: Modifier = Modifier) {
             Text("Favorite Events",
                 style = typography.headlineMedium,
                 color = colorScheme.onBackground,
-                modifier = Modifier.padding(top = 16.dp))
+                modifier = Modifier.padding(top = 16.dp)
+                    .semantics { heading() })
         }
         Spacer(modifier = Modifier.height(4.dp))
 
@@ -90,7 +96,13 @@ fun FavoritesScreen(modifier: Modifier = Modifier) {
                     "You haven't favorited any events yet.",
                     style = typography.titleLarge,
                     color = colorScheme.onBackground,
-                    textAlign = TextAlign.Center
+                    textAlign = TextAlign.Center,
+                    // This ensures we alert a screen reader when we have no favorited events yet
+                    modifier = Modifier.semantics {
+                        liveRegion = LiveRegionMode.Polite
+                        contentDescription = "You haven't favorited any events yet"
+                    }
+
                 )
             }
         } else {

--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/screens/HomeScreen.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/screens/HomeScreen.kt
@@ -42,6 +42,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.example.myapplication.AppRepository
@@ -169,8 +175,9 @@ fun HomeScreen(tags: List<Check>) {
                         Row(verticalAlignment = Alignment.CenterVertically) {
                             Icon(
                                 imageVector = Icons.Filled.DateRange,
-                                contentDescription = "Calendar Icon",
+                                contentDescription = "Select Day Filter",
                                 modifier = Modifier.size(20.dp)
+                                    .semantics { role = Role.Button }
                             )
                             Spacer(Modifier.size(8.dp))
                             // displays selected day on button
@@ -220,8 +227,9 @@ fun HomeScreen(tags: List<Check>) {
                         Row(verticalAlignment = Alignment.CenterVertically) {
                             Icon(
                                 imageVector = Icons.Outlined.FilterAlt,
-                                contentDescription = "Filter Icon",
+                                contentDescription = "Select Tags Filters",
                                 modifier = Modifier.size(20.dp)
+                                    .semantics { role = Role.Button }
                             )
                             Spacer(Modifier.size(8.dp))
 
@@ -320,7 +328,13 @@ fun HomeScreen(tags: List<Check>) {
                 Text(
                     "No more events match filters",
                     style = typography.titleLarge,
-                    fontWeight = FontWeight.Bold
+                    fontWeight = FontWeight.Bold,
+                    // This ensures we alert a screen reader when we have scrolled down to this section
+                    modifier = Modifier.semantics {
+                        liveRegion = LiveRegionMode.Polite
+                        contentDescription = "No more events match filters."
+                    }
+
                 )
                 Spacer(modifier = Modifier.height(120.dp))
 

--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/screens/HomeScreen.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/screens/HomeScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.ExperimentalMaterialApi
@@ -146,7 +147,8 @@ fun HomeScreen(tags: List<Check>) {
             //creates a row to align the logo and buttons on the home page
             Row(
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(4.dp)
+                horizontalArrangement = Arrangement.SpaceBetween,
+                modifier = Modifier.fillMaxWidth()
             )
             {
                 // adds the logo to the top
@@ -154,14 +156,17 @@ fun HomeScreen(tags: List<Check>) {
                     painter = painterResource(id = R.drawable.getgrinnected_logo),
                     contentDescription = "App Logo",
                     modifier = Modifier
-                        .padding(25.dp)
+                        .padding(start = 6.dp, top = 25.dp, end = 6.dp)
                         .background(Color.White)
                         .size(50.dp)
                 )
+
                 // centers the buttons
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.End
+                    horizontalArrangement = Arrangement.Center,
+                    modifier = Modifier.weight(1f)
+                        .padding(top = 25.dp)
                 ) {
                     // creates day menu
                     Button(
@@ -179,11 +184,22 @@ fun HomeScreen(tags: List<Check>) {
                                 modifier = Modifier.size(20.dp)
                                     .semantics { role = Role.Button }
                             )
-                            Spacer(Modifier.size(8.dp))
+                            Spacer(Modifier.size(6.dp))
                             // displays selected day on button
-                            Text(daysList[selectedView].dayOfWeek.getDisplayName(java.time.format.TextStyle.FULL, Locale.getDefault()).substring(0, 3) + ", " + toMonth(daysList[selectedView]) + " " + daysList[selectedView].format(formatter3), style = typography.labelLarge)
+                            Text(
+                                daysList[selectedView].dayOfWeek.getDisplayName(
+                                    java.time.format.TextStyle.FULL,
+                                    Locale.getDefault()
+                                ).substring(
+                                    0,
+                                    3
+                                ) + ", " + toMonth(daysList[selectedView]) + " " + daysList[selectedView].format(
+                                    formatter3
+                                ), style = typography.labelLarge
+                            )
                         }
                     }
+                    Spacer(Modifier.size(6.dp))
                     // creates dropdown menu when button is clicked
                     DropdownMenu(
                         expanded = expanded.value,
@@ -207,14 +223,6 @@ fun HomeScreen(tags: List<Check>) {
                             })
                         }
                     }
-                }
-                // I don't know why this is necessary but was needed to properly space tag menu
-                Row(
-                    modifier = Modifier
-                        .padding(8.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.End,
-                ) {
                     // creates tags menu
                     Button(
                         onClick = { expanded2.value = true },
@@ -231,7 +239,7 @@ fun HomeScreen(tags: List<Check>) {
                                 modifier = Modifier.size(20.dp)
                                     .semantics { role = Role.Button }
                             )
-                            Spacer(Modifier.size(8.dp))
+                            Spacer(Modifier.size(6.dp))
 
                             Text("Tags", style = typography.labelLarge, maxLines = 1)
                         }

--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/screens/LoginScreen.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/screens/LoginScreen.kt
@@ -34,6 +34,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -130,7 +132,7 @@ fun LoginScreen(modifier: Modifier, navController: NavController) {
                 leadingIcon = {
                     Icon(
                         imageVector = Icons.Filled.Email,
-                        contentDescription = "Email Icon",
+                        contentDescription = "Email input field Icon",
                         modifier = Modifier.size(24.dp)
                     )
                 },
@@ -221,6 +223,7 @@ fun LoginScreen(modifier: Modifier, navController: NavController) {
                     Text(
                         text = "Join now",
                         style = typography.labelLarge,
+                        modifier = modifier.semantics { contentDescription = "Sign Up for an account" }
                     )
                 }
             }

--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/screens/SettingsScreen.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/screens/SettingsScreen.kt
@@ -59,6 +59,12 @@ import androidx.compose.ui.res.painterResource
 import androidx.core.net.toUri
 import com.example.myapplication.R
 import androidx.compose.material3.SwitchDefaults
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import com.example.myapplication.AppRepository.deleteAccount
 
 /**
@@ -124,7 +130,8 @@ fun SettingsScreen(modifier: Modifier = Modifier,
             Text(
                 text = "Preferences",
                 style = typography.headlineMedium,
-                color = colorScheme.onBackground
+                color = colorScheme.onBackground,
+                modifier = modifier.semantics { heading() }
             )
             Spacer(modifier = Modifier.height(4.dp))
             HorizontalDivider()
@@ -259,11 +266,13 @@ fun SettingsScreen(modifier: Modifier = Modifier,
                     Switch(
                         checked = darkTheme,
                         onCheckedChange = { onToggleTheme(it) },
-
                         colors = SwitchDefaults.colors(
                             checkedThumbColor = MaterialTheme.colorScheme.onPrimary,
                             checkedTrackColor = MaterialTheme.colorScheme.secondary,
-                        )
+                        ),
+                        modifier = Modifier.semantics {
+                            stateDescription = if (darkTheme) "Dark mode is on" else "Dark mode is off"
+                        }
                     )
                 }
             }
@@ -351,7 +360,7 @@ fun SettingsScreen(modifier: Modifier = Modifier,
                         }) {
                             Icon(
                                 painter = painterResource(id = R.drawable.github_mark),
-                                contentDescription = "GitHub",
+                                contentDescription = "Press to Navigate to GitHub Repository",
                                 tint = colorScheme.tertiary,
                                 modifier = Modifier.size(32.dp)
                             )
@@ -364,7 +373,7 @@ fun SettingsScreen(modifier: Modifier = Modifier,
                         }) {
                             Icon(
                                 painter = painterResource(R.drawable.discord_icon_svgrepo_com),
-                                contentDescription = "Discord",
+                                contentDescription = "Press to Navigate to Discord",
                                 tint = colorScheme.tertiary,
                                 modifier = Modifier.size(32.dp)
                             )
@@ -382,7 +391,10 @@ fun SettingsScreen(modifier: Modifier = Modifier,
                 .fillMaxWidth()) {
                 Text(text = "Delete Account",
                     style = typography.bodyLarge,
-                    color = colorScheme.tertiary)
+                    color = colorScheme.tertiary,
+                    modifier = modifier.semantics {
+                        contentDescription = "Delete your account"
+                        role = Role.Button})
             }
 
             if (showDeleteDialog) {
@@ -549,6 +561,10 @@ fun SettingsSection(
             modifier = Modifier
                 .clickable { expanded = !expanded }
                 .padding(12.dp)
+                .semantics {
+                    role = Role.Button
+                    contentDescription = "$title section, ${if (expanded) "expanded" else "collapsed"}. Tap to ${if (expanded) "collapse" else "expand"}."
+                }
         ) {
             Row(
                 verticalAlignment = Alignment.CenterVertically,
@@ -560,6 +576,7 @@ fun SettingsSection(
                     style = typography.titleLarge,
                     color = colorScheme.onSurface,
                     modifier = Modifier.weight(1f)
+                        .semantics { heading() }
                 )
                 // Icon associated with expanded or not
                 Icon(

--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/screens/SettingsScreen.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/screens/SettingsScreen.kt
@@ -338,12 +338,37 @@ fun SettingsScreen(modifier: Modifier = Modifier,
 
                 Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
                     Text(
+                        text = "GetGrinnected was developed by Grinnellians, for Grinnellians, with the goal of creating an intuitive and accessible platform to stay informed about campus events.",
+                        style = typography.bodyMedium,
+                        color = colorScheme.onBackground
+                    )
+
+                    Text(
                         text = "Acknowledgements",
                         style = typography.titleMedium,
                         color = colorScheme.onBackground
                     )
+
                     Text(
-                        text = "Some text about stakeholders or mission",
+                        text = "We are deeply grateful to the amazing individuals who helped bring GetGrinnected to life:",
+                        style = typography.bodyMedium,
+                        color = colorScheme.onBackground
+                    )
+
+                    Text(
+                        text = "Logo Design:\n" +
+                                "• Rei \n" +
+                                "Testing & Stakeholder Feedback:\n" +
+                                "• Yuina Iseki\n" +
+                                "• Lily Freeman\n" +
+                                "• Regan Stambaugh\n" +
+                                "Development Team:\n" +
+                                "• Ellie Seehorn \n" +
+                                "• Michael Paulin \n" +
+                                "• Budhil Thijm \n" +
+                                "• Almond Heil \n" +
+                                "• Ethan Hughes \n" +
+                                "• Anthony Schwindt",
                         style = typography.bodyMedium,
                         color = colorScheme.onBackground
                     )

--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/screens/SettingsScreen.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/screens/SettingsScreen.kt
@@ -1,6 +1,7 @@
 package screens
 
 import android.content.Intent
+import android.widget.Toast
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -58,6 +59,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.core.net.toUri
 import com.example.myapplication.R
 import androidx.compose.material3.SwitchDefaults
+import com.example.myapplication.AppRepository.deleteAccount
 
 /**
  * A composable function that represents the Settings screen of our app.
@@ -399,7 +401,18 @@ fun SettingsScreen(modifier: Modifier = Modifier,
                         TextButton(
                             onClick = {
                                 coroutineScope.launch {
-                                   //TODO Delete Account
+                                    val success = deleteAccount(context)
+                                    if (success) {
+                                        // clear user session
+                                        DataStoreSettings.clearUserSession(context)
+                                        onToggleTheme(false)
+                                        navController.navigate("welcome") {
+                                            popUpTo(0) { inclusive = true }
+                                            launchSingleTop = true
+                                        }
+                                    } else {
+                                        Toast.makeText(context, "Couldn't Delete Account at this time try again later", Toast.LENGTH_LONG).show()
+                                    }
                                 }
                                 showDeleteDialog = false
                             },

--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/screens/SignupScreen.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/screens/SignupScreen.kt
@@ -36,6 +36,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -135,7 +137,7 @@ fun SignupScreen(modifier: Modifier, navController: NavController) {
                 leadingIcon = {
                     Icon(
                         imageVector = Icons.Filled.Person,
-                        contentDescription = "Email Icon",
+                        contentDescription = "Username field input icon",
                         modifier = Modifier.size(24.dp)
                     )
                 },
@@ -165,7 +167,7 @@ fun SignupScreen(modifier: Modifier, navController: NavController) {
                 leadingIcon = {
                     Icon(
                         imageVector = Icons.Filled.Email,
-                        contentDescription = "Email Icon",
+                        contentDescription = "Email input field icon",
                         modifier = Modifier.size(24.dp)
                     )
                 },
@@ -264,7 +266,9 @@ fun SignupScreen(modifier: Modifier, navController: NavController) {
                     color = colorScheme.onBackground
                 )
                 TextButton(onClick = { navController.navigate("login") }) {
-                    Text(text = "Sign in", style = typography.labelLarge)
+                    Text(text = "Sign in",
+                        style = typography.labelLarge,
+                        modifier = modifier.semantics { contentDescription = "Log in to your account" })
                 }
             }
 

--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/screens/SignupScreen.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/screens/SignupScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
@@ -113,7 +114,11 @@ fun SignupScreen(modifier: Modifier, navController: NavController) {
             Text(
                 text = "Welcome to GetGrinnected",
                 style = typography.headlineMedium,
-                color = colorScheme.onBackground
+                color = colorScheme.onBackground,
+                modifier = Modifier
+                    .padding(horizontal = 8.dp)
+                    .fillMaxWidth(),
+                textAlign = TextAlign.Center,
             )
 
             Spacer(modifier = Modifier.height(4.dp))

--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/screens/WelcomeScreen.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/screens/WelcomeScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
@@ -17,6 +18,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
@@ -57,7 +59,6 @@ fun WelcomeScreen(modifier: Modifier, navController: NavController) {
                 painter = painterResource(id = R.drawable.getgrinnected_logo),
                 contentDescription = "App Logo",
                 modifier = Modifier
-                    .fillMaxWidth()
                     .size(250.dp)
             )
 
@@ -66,7 +67,11 @@ fun WelcomeScreen(modifier: Modifier, navController: NavController) {
             Text(
                 text = "Welcome to GetGrinnected",
                 style = typography.headlineMedium,
-                color = colorScheme.onBackground
+                color = colorScheme.onBackground,
+                modifier = Modifier
+                    .padding(horizontal = 8.dp)
+                    .fillMaxWidth(),
+                textAlign = TextAlign.Center,
             )
 
             Spacer(modifier = Modifier.height(24.dp))


### PR DESCRIPTION
In this PR I kind of did a wide range of things.
- Implemented the delete user path with the API to actually delete the user account and be more than just UI
- I increased the size scaling of the enum values for font sizing to be more realistic to sizings
- I added alt text and semantics to handle screen readers
- I also changed some centering issues in the login process with our welcome text and spacing of our buttons on the home page.