### PR TITLE
Make a build where apple testers don't need a real password

### DIFF
--- a/src/backend/api/routes/user.cjs
+++ b/src/backend/api/routes/user.cjs
@@ -134,18 +134,24 @@ async function routeVerifyOTP(req, res, _next) {
   // we can assume they exist thanks to the middleware.
   const email = req.body.email;
   const code = req.body.code;
+  bypass = false;
+
+  if (email.toLowerCase() == 'getgrinnected.demo@grinnell.edu'){
+    //give permission to verify regardless of the input
+    bypass= true;
+  }
 
   // Check the OTP code the user entered against the codes we have stored.
   // If it does not match (wrong code or expired), return the same error with
   // HTTP status 400.
   validCode = await util.otpFileCheck(DBPATH, email, code)
-  if (!validCode) {
+  if (!validCode && !bypass) {//the code is wrong AND we don't have permission to bypass
     res.status(400).json({
       'error': 'Bad code',
       'message': 'Could not verify OTP.'
     });
     return;
-  } else {
+  } else {//the code was right OR we have permission to bypass (for apple account)
     // Generate tokens for that user
     const tokens = util.generateUserTokens(email);
 


### PR DESCRIPTION
This PR exists primarily bc whoever is testing for testflight beta either cannot read instructions or chose not to follow them and is trying to log in with a not Grinnell email, rather than logging in with a Grinnell one and going to a provided Gmail to get the code. It updates the API such that when the very specific grinnell email is provided, any code they put in will suffice, eliminating the need for Gmail. I submit an appeal of the old one, but it seems like it might be genuinely faster to submit a "new build" (it will be identical swift) than see that process through. ugh