### PR TITLE
Change name order on settings pages

### DIFF
--- a/src/android/GetGrinnected/MyApplication/app/src/main/java/screens/SettingsScreen.kt
+++ b/src/android/GetGrinnected/MyApplication/app/src/main/java/screens/SettingsScreen.kt
@@ -553,12 +553,12 @@ fun SettingsScreen(modifier: Modifier = Modifier,
                             )
 
                             Text(
-                                text = "• Ellie Seehorn \n" +
-                                        "• Michael Paulin \n" +
+                                text = "• almond Heil \n" +
+                                        "• Anthony Schwindt \n" +
                                         "• Budhil Thijm \n" +
-                                        "• Almond Heil \n" +
+                                        "• Ellie Seehorn \n" +
                                         "• Ethan Hughes \n" +
-                                        "• Anthony Schwindt",
+                                        "• Michael Paulin",
                                 style = typography.bodyMedium,
                                 color = colorScheme.onBackground
                             )

--- a/src/ios/GetGrinnected/GetGrinnected/CoreViews/SettingsView.swift
+++ b/src/ios/GetGrinnected/GetGrinnected/CoreViews/SettingsView.swift
@@ -367,7 +367,7 @@ struct SettingsView: View {
                         
                     Text("Development Team")
                         .font(.headline)
-                    Text("Almond Heil")
+                    Text("almond Heil")
                     Text("Anthony Schwindt")
                     Text("Budhil Thijm")
                     Text("Ellie Seehorn")

--- a/src/ios/GetGrinnected/GetGrinnected/CoreViews/SettingsView.swift
+++ b/src/ios/GetGrinnected/GetGrinnected/CoreViews/SettingsView.swift
@@ -367,12 +367,12 @@ struct SettingsView: View {
                         
                     Text("Development Team")
                         .font(.headline)
-                    Text("Ellie Seehorn '25")
-                    Text("Michael Paulin '25")
-                    Text("Almond Heil '25")
-                    Text("Budhil Thijm '25")
-                    Text("Ethan Hughes '25")
-                    Text("Anthony Schwindt '25")
+                    Text("Almond Heil")
+                    Text("Anthony Schwindt")
+                    Text("Budhil Thijm")
+                    Text("Ellie Seehorn")
+                    Text("Ethan Hughes")
+                    Text("Michael Paulin")
                         .padding(.bottom)
                     
                     Text("Faculty Instructor")


### PR DESCRIPTION
This PR puts our names in the alphabetical order by first name on both settings pages.

* almond Heil
* Anthony Schwindt
* Budhil Thijm
* Ellie Seehorn
* Ethan Hughes
* Michael Paulin

Before it was really unclear what the order was, and they were in a different order.

I'm open to a different ordering, but we want it to make sense and we want it to be the same across both apps. I don't especially like being at the front but that happens unless we sort `a` after `A-Z`, which Ellie reminds me is weird.