### PR TITLE
Create script to delete expired one-time codes

### DIFF
--- a/src/backend/clean_otp_codes.cjs
+++ b/src/backend/clean_otp_codes.cjs
@@ -1,6 +1,14 @@
 const sqlite3 = require('sqlite3');
 const DBPATH = './src/backend/Database/localOTP.db'
 
+/**
+ * Clean any expired OTP codes in the specified filename. Codes will be cleaned up
+ * if their expiration time is less than the current time when this function is called.
+ * 
+ * If any error happens with the database, will print that error to the screen.
+ * 
+ * @param {string} filename Filename of sqlite database to target.
+ */
 async function otpFileClean(filename) {
     // Format the current time in the same format as the database
     //   example: 2025-05-13T18:51:51.899Z


### PR DESCRIPTION
This PR creates a script that deletes any expired one-time codes from the sqlite3 database, which stops them from piling up if people do not verify them.

I have tested it with both expired and non-expired codes on my machine, but no automatic testing of this component is planned right now.

When it is merged, I can add a cron job on the server that runs this script every 12 hours or something.